### PR TITLE
Stub Lambda and add packaging support for deployment

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "anghammarad"
+name         := "anghammarad"
 organization := "com.gu"
 scalaVersion := "2.12.4"
 version      := "0.1.0-SNAPSHOT"
@@ -9,9 +9,20 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "1.3.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-lambda" % awsSdkVersion,
+  "com.vladsch.flexmark" % "flexmark-all" % "0.32.18",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0",
   "ch.qos.logback" %  "logback-classic" % "1.1.7",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )
 
-scalacOptions := Seq("-unchecked", "-deprecation")
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-Xfatal-warnings",
+  "-encoding", "UTF-8",
+  "-target:jvm-1.8",
+  "-Ywarn-dead-code"
+)
+
+enablePlugins(JavaAppPackaging)
+topLevelDirectory in Universal := None
+packageName in Universal := normalizedName.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")

--- a/src/main/scala/com/gu/anghammarad/Main.scala
+++ b/src/main/scala/com/gu/anghammarad/Main.scala
@@ -1,11 +1,26 @@
 package com.gu.anghammarad
 
-
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import collection.JavaConverters._
+
 
 class Main extends RequestHandler[SNSEvent, Unit] {
   override def handleRequest(input: SNSEvent, context: Context): Unit = {
+    val msgs = input.getRecords.asScala.map { snsRecord =>
+      val msgId = snsRecord.getSNS.getMessageId
 
+      val msgType = snsRecord.getSNS.getType
+      val source = snsRecord.getEventSource
+      val timestamp = snsRecord.getSNS.getTimestamp
+
+      val subject = snsRecord.getSNS.getSubject
+      val message = snsRecord.getSNS.getMessage
+      val msgAttrs = snsRecord.getSNS.getMessageAttributes.asScala.map { case (key, msgAttr) =>
+        s"$key [${msgAttr.getType}]: ${msgAttr.getValue}"
+      }.mkString("{", ",", "}")
+      s"$msgId ($msgType $source $timestamp): [$subject] $message $msgAttrs"
+    }
+    context.getLogger.log(msgs.mkString("{", ",", "}"))
   }
 }


### PR DESCRIPTION
We can now create a deployable zip using `packageBin` from the `sbt` shell. It'll put a zip file called `anghammarad.zip` in `target/universal` relative to the project directory.

Lambda just outputs the notification to logs so we can see the format, for now.
