### PR TITLE
Parse the config into Configuration, and add email sender

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
@@ -11,9 +11,9 @@ class Lambda extends RequestHandler[SNSEvent, Unit] {
 
     val result = for {
       config <- Config.loadConfig(stage)
-      mappings <- Serialization.parseAllMappings(config)
+      configuration <- Serialization.parseConfig(config)
       notification <- Serialization.parseNotification(input)
-      _ <- Anghammarad.run(notification, mappings)
+      _ <- Anghammarad.run(notification, configuration.mappings)
     } yield ()
 
     // send notification if result is a failure

--- a/anghammarad/src/main/scala/com/gu/anghammarad/models/Serialization.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/models/Serialization.scala
@@ -12,6 +12,38 @@ import scala.util.{Failure, Success, Try}
 
 
 object Serialization {
+  def parseConfig(config: String): Try[Configuration] = {
+    for {
+      emailDomain <- parseEmailDomain(config)
+      emailSender <- parseEmailSender(config)
+      mappings <- parseAllMappings(config)
+    } yield Configuration(emailDomain, emailSender, mappings)
+  }
+
+  private def parseEmailDomain(jsonStr: String): Try[String] = {
+    val emailDomain = for {
+      json <- parse(jsonStr)
+      sender <- json.hcursor.downField("emailDomain").as[String]
+    } yield sender
+
+    emailDomain.fold(
+      err => Failure(err),
+      mappings => Success(mappings)
+    )
+  }
+
+  private def parseEmailSender(jsonStr: String): Try[String] = {
+    val emailSender = for {
+      json <- parse(jsonStr)
+      sender <- json.hcursor.downField("emailSender").as[String]
+    } yield sender
+
+    emailSender.fold(
+      err => Failure(err),
+      mappings => Success(mappings)
+    )
+  }
+
   def parseNotification(snsEvent: SNSEvent): Try[Notification] = {
     val maybeSns = snsEvent.getRecords.asScala.toList match {
       case singleRecord :: Nil => Success(singleRecord.getSNS)

--- a/anghammarad/src/main/scala/com/gu/anghammarad/models/models.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/models/models.scala
@@ -18,6 +18,12 @@ sealed trait Contact
 case class EmailAddress(address: String) extends Contact
 case class HangoutsRoom(webhook: String) extends Contact
 
+case class Configuration(
+  emailDomain: String,
+  emailSender: String,
+  mappings: List[Mapping]
+)
+
 case class Mapping(
   targets: List[Target],
   contacts: List[Contact]

--- a/anghammarad/src/test/resources/config.json
+++ b/anghammarad/src/test/resources/config.json
@@ -1,5 +1,6 @@
 {
-  "emailDomain": "example.com",
+  "emailDomain": "@example.com",
+  "emailSender": "sender@example.com",
   "mappings": [
     {
       "target": {
@@ -26,6 +27,15 @@
       },
       "contacts": {
         "email": "awsAccount.email"
+      }
+    },
+    {
+      "target": {
+        "Stack": "postal-service",
+        "App": "clacks-overhead"
+      },
+      "contacts": {
+        "email": "discworld.email"
       }
     }
   ]

--- a/anghammarad/src/test/scala/com/gu/anghammarad/models/SerializationTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/models/SerializationTest.scala
@@ -104,7 +104,8 @@ class SerializationTest extends FreeSpec with Matchers with EitherValues {
       val expectedResult = List(
         Mapping(List(Stack("stack1")), List(EmailAddress("stack1.email"), HangoutsRoom("stack1.room"))),
         Mapping(List(Stack("stack1"), App("app1")), List(EmailAddress("app1.email"), HangoutsRoom("app1.room"))),
-        Mapping(List(AwsAccount("123456789")), List(EmailAddress("awsAccount.email")))
+        Mapping(List(AwsAccount("123456789")), List(EmailAddress("awsAccount.email"))),
+        Mapping(List(Stack("postal-service"), App("clacks-overhead")), List(EmailAddress("discworld.email")))
       )
 
       Serialization.parseAllMappings(validJsonString).get shouldEqual expectedResult


### PR DESCRIPTION
Serialization needs and overhaul, yet it keeps growing 🙈 

Running will now parse an entire config giving the mappings, email sender and email domain