### PR TITLE
Fix display of messages with no actions in Hangouts Chat

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
@@ -75,8 +75,7 @@ object Messages {
       .replace("<p>", "").replace("</p>", "<br>")
 
     val json =
-      s"""
-         |{
+      s"""{
          |  "cards": [
          |    {
          |      "sections": [
@@ -89,16 +88,7 @@ object Messages {
          |              }
          |            }
          |          ]
-         |        },
-         |        {
-         |          "widgets": [
-         |            {
-         |              "buttons": [
-         |                ${notification.actions.map(textButtonJson).mkString(",")}
-         |              ]
-         |            }
-         |          ]
-         |        }
+         |        }${buttonJson(notification.actions)}
          |      ]
          |    }
          |  ]
@@ -107,9 +97,25 @@ object Messages {
     HangoutMessage(json)
   }
 
+  private def buttonJson(actions: List[Action]): String = {
+    if (actions.isEmpty) {
+      ""
+    } else {
+      s""",
+         |{
+         |  "widgets": [
+         |    {
+         |      "buttons": [
+         |        ${actions.map(textButtonJson).mkString(",")}
+         |      ]
+         |    }
+         |  ]
+         |}""".stripMargin
+    }
+  }
+
   private def textButtonJson(action: Action): String = {
-    s"""
-       |{
+    s"""{
        |  "textButton": {
        |    "text": ${Json.fromString(action.cta).noSpaces},
        |    "onClick": {

--- a/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
@@ -1,14 +1,15 @@
 package com.gu.anghammarad
 
-import com.gu.anghammarad.models._
 import com.gu.anghammarad.messages.Messages._
 import com.gu.anghammarad.messages.{HangoutsService, Messages}
+import com.gu.anghammarad.models._
 import io.circe.parser._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.{EitherValues, FreeSpec, Matchers}
+
 import scala.util.{Failure, Success}
 
 
-class MessagesTest extends FreeSpec with Matchers {
+class MessagesTest extends FreeSpec with Matchers with EitherValues {
   "emailMessage" - {
     "plain text" - {
       "sets the subject" in {
@@ -99,6 +100,17 @@ class MessagesTest extends FreeSpec with Matchers {
           case Left(err) => throw err
         }
       }
+
+      "includes buttons for actions" in {
+        val message = hangoutMessage(notification)
+        val json = parse(message.cardJson).right.value
+        json.\\("textButton") should have length 2
+      }
+
+      "sets header as subject" in {
+        val message = hangoutMessage(notification)
+        message.cardJson should include(s""""header": "subject"""")
+      }
     }
 
     "if no actions are present" - {
@@ -113,6 +125,11 @@ class MessagesTest extends FreeSpec with Matchers {
         }
       }
 
+      "does not include buttons widgets at all" in {
+        val message = hangoutMessage(notification)
+        val json = parse(message.cardJson).right.value
+        json.\\("buttons") shouldBe empty
+      }
     }
   }
 


### PR DESCRIPTION
A buttons widget with no buttons is not valid, and will just display an empty card. We now omit the entire section if there are no buttons to display.