### PR TITLE
Allow the Lambda to access the configuration files in S3

### DIFF
--- a/cloudformation/anghammarad.template.yaml
+++ b/cloudformation/anghammarad.template.yaml
@@ -9,6 +9,9 @@ Parameters:
   ArtifactLocation:
     Description: S3 path to the Lambda's artifact
     Type: String
+  ConfigBucket:
+    Description: S3 bucket containing the configuration
+    Type: String
   Stage:
     Description: Application stage (e.g. PROD, CODE)
     Type: String
@@ -37,6 +40,11 @@ Resources:
             Action:
             - ses:SendEmail
             Resource: "*"
+      - Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: !Sub arn:aws:s3:::${ConfigBucket}/*
       Handler: com.gu.anghammarad.Lambda::handleRequest
       Runtime: java8
       MemorySize: 512


### PR DESCRIPTION
The other tools in this account seem to follow a pattern of a separate configuration folder. So that is how I have set it up for now. `Config.scala` will still load the config file according to the Stage (`DEV`/`PROD`), which might be helpful if we want to ensure local testing can never send false alarms to teams!

Testing with DevMain and CLI invocation seem to be working okay:

<img width="397" alt="picture 274" src="https://user-images.githubusercontent.com/8607683/37977345-701649c0-31db-11e8-899a-2e2b84b1a6bd.png">

<img width="416" alt="picture 275" src="https://user-images.githubusercontent.com/8607683/37979011-64a0632e-31df-11e8-9453-72ebc72ea6e0.png">

