### PR TITLE
Client library

### DIFF
--- a/client/src/main/scala/com/gu/anghammarad/AWS.scala
+++ b/client/src/main/scala/com/gu/anghammarad/AWS.scala
@@ -1,7 +1,8 @@
 package com.gu.anghammarad
 
 import com.amazonaws.AmazonWebServiceRequest
-import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider}
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.sns.{AmazonSNSAsync, AmazonSNSAsyncClientBuilder}
@@ -13,11 +14,22 @@ object AWS {
   /**
     * Use this to make an SNS client, or provide your own.
     */
-  def client(credentialsProvider: AWSCredentialsProviderChain): AmazonSNSAsync = {
+  def snsClient(credentialsProvider: AWSCredentialsProviderChain): AmazonSNSAsync = {
     AmazonSNSAsyncClientBuilder.standard()
       .withRegion(Regions.EU_WEST_1)
       .withCredentials(credentialsProvider)
       .build()
+  }
+
+  def credentialsProvider(): AWSCredentialsProviderChain = {
+    new AWSCredentialsProviderChain(
+      // EC2
+      InstanceProfileCredentialsProvider.getInstance(),
+      // Lambda
+      new EnvironmentVariableCredentialsProvider(),
+      // local
+      new ProfileCredentialsProvider("deployTools")
+    )
   }
 
   private class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T]) extends AsyncHandler[R, T] {

--- a/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
+++ b/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
@@ -11,6 +11,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object Anghammarad {
   /**
+    * Sends a notification using Anghammarad.
+    *
     * @param subject      Used for the subject in emails and the heading of hangouts chat notifications
     * @param message      The message body. Supports markdown, but support differs between notification channels
     * @param sourceSystem The system sending the notification (your system)
@@ -30,5 +32,26 @@ object Anghammarad {
       .withSubject(subject)
       .withMessage(messageJson(message, sourceSystem, channel, target, actions))
     awsToScala(client.publishAsync)(request).map(_.getMessageId)
+  }
+
+  /**
+    * Use a default SNS client to create a notification.
+    *
+    * @param subject      Used for the subject in emails and the heading of hangouts chat notifications
+    * @param message      The message body. Supports markdown, but support differs between notification channels
+    * @param sourceSystem The system sending the notification (your system)
+    * @param channel      The notification channel you'd like to use
+    * @param target       Specify who should receive the message
+    * @param actions      Specify Call To Action buttons that will be put at the end of an email / hangout message
+    * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
+    * @return             Future of the resulting SNS Message ID
+    */
+  def notify(subject: String, message: String, sourceSystem: String,
+             channel: RequestedChannel, target: List[Target], actions: List[Action],
+             topicArn: String)
+            (implicit executionContext: ExecutionContext): Future[String] = {
+    val credentialsProvider = AWS.credentialsProvider()
+    val client = AWS.snsClient(credentialsProvider)
+    notify(subject, message, sourceSystem, channel, target, actions, topicArn, client)
   }
 }

--- a/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
+++ b/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
@@ -25,33 +25,13 @@ object Anghammarad {
     */
   def notify(subject: String, message: String, sourceSystem: String,
              channel: RequestedChannel, target: List[Target], actions: List[Action],
-             topicArn: String, client: AmazonSNSAsync)
+             topicArn: String,
+             client: AmazonSNSAsync = AWS.snsClient(AWS.credentialsProvider()))
             (implicit executionContext: ExecutionContext): Future[String] = {
     val request = new PublishRequest()
       .withTopicArn(topicArn)
       .withSubject(subject)
       .withMessage(messageJson(message, sourceSystem, channel, target, actions))
     awsToScala(client.publishAsync)(request).map(_.getMessageId)
-  }
-
-  /**
-    * Use a default SNS client to create a notification.
-    *
-    * @param subject      Used for the subject in emails and the heading of hangouts chat notifications
-    * @param message      The message body. Supports markdown, but support differs between notification channels
-    * @param sourceSystem The system sending the notification (your system)
-    * @param channel      The notification channel you'd like to use
-    * @param target       Specify who should receive the message
-    * @param actions      Specify Call To Action buttons that will be put at the end of an email / hangout message
-    * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
-    * @return             Future of the resulting SNS Message ID
-    */
-  def notify(subject: String, message: String, sourceSystem: String,
-             channel: RequestedChannel, target: List[Target], actions: List[Action],
-             topicArn: String)
-            (implicit executionContext: ExecutionContext): Future[String] = {
-    val credentialsProvider = AWS.credentialsProvider()
-    val client = AWS.snsClient(credentialsProvider)
-    notify(subject, message, sourceSystem, channel, target, actions, topicArn, client)
   }
 }


### PR DESCRIPTION
If you call without a client we'll use one that makes sense for us. This is useful for Guardian developers, which is our only audience for now.

This uses a default argument for the client parameter. I'm open to using separate functions instead, except that it means duplicating the big chunk of documentation.