### PR TITLE
Adds the final `sonatypeRelease` step to `sbt release`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,8 @@ lazy val client = project
     ),
     scalacOptions ++= compilerOptions,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-    publishTo := sonatypePublishTo.value
+    publishTo := sonatypePublishTo.value,
+    releaseProcess += releaseStepCommandAndRemaining("sonatypeRelease")
   )
 
 lazy val anghammarad = project


### PR DESCRIPTION
This means `sbt release` will do an end-to-end production release of the client library. To test it first, publish a snaphsot version and/or publishLocal.