### PR TITLE
Implements proper message routing logic

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
@@ -9,6 +9,12 @@ import scala.util.{Success, Try}
 object Contacts {
   /**
     * Gets all available contacts for this target, from configuration.
+    *
+    * The logic is complex, the tests are a good reference for the expected behaviour.
+    *
+    * Exact matches are prioritised, then we apply logic to route other messages correctly.
+    * App, Stack and AWS Account use a hierarchy, App > Stack > AwsAccount.
+    * Stage treats PROD as the default and is required for a non-PROD match.
     */
   def resolveTargetContacts(targets: List[Target], mappings: List[Mapping]): Try[List[Contact]] = {
     mappings.filter(_.targets.toSet == targets.toSet) match {

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
@@ -56,7 +56,7 @@ object Contacts {
     * Mapping has:
     *   Stack("stack"), App("app")
     *
-    * This is tricky because we wouldn't to match on the following
+    * This is tricky because we wouldn't want to match on the following
     *
     * Ask for:
     *   Stack("stack")

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
@@ -11,7 +11,7 @@ object Contacts {
     * Gets all available contacts for this target, from configuration.
     */
   def resolveTargetContacts(targets: List[Target], mappings: List[Mapping]): Try[List[Contact]] = {
-    mappings.filter(_.targets == targets) match {
+    mappings.filter(_.targets.toSet == targets.toSet) match {
       case Nil =>
         mappings.filter { case Mapping(mappingTargets, _) =>
           targets.toSet subsetOf mappingTargets.toSet

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
@@ -53,4 +53,13 @@ object Targets {
     val stages2 = targets2.collect(collectApp).toSet
     (stages1 intersect stages2).nonEmpty
   }
+
+  def sortMappingsByTargets(targets: List[Target], mappings: List[Mapping]): List[Mapping] = {
+    mappings.sortBy { mapping =>
+      ( appMatches(mapping.targets, targets)
+      , stackMatches(mapping.targets, targets)
+      , awsAccountMatches(mapping.targets, targets)
+      )
+    }.reverse
+  }
 }

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
@@ -1,0 +1,56 @@
+package com.gu.anghammarad
+
+import com.gu.anghammarad.models._
+
+
+object Targets {
+  private val collectAwsAccount: PartialFunction[Target, AwsAccount] = { case a @ AwsAccount(_) => a }
+  private val collectStack: PartialFunction[Target, Stack] = { case s @ Stack(_) => s }
+  private val collectApp: PartialFunction[Target, App] = { case a @ App(_) => a }
+  private val collectStage: PartialFunction[Target, Stage] = { case s @ Stage(_) => s }
+
+  def normaliseStages(targets: List[Target]): List[Target] = {
+    if (includesStage(targets)) targets
+    else Stage("PROD") :: targets
+  }
+
+  def includesAwsAccount(targets: List[Target]): Boolean = {
+    targets.collect(collectAwsAccount).nonEmpty
+  }
+
+  def includesStack(targets: List[Target]): Boolean = {
+    targets.collect(collectStack).nonEmpty
+  }
+
+  def includesApp(targets: List[Target]): Boolean = {
+    targets.collect(collectApp).nonEmpty
+  }
+
+  def includesStage(targets: List[Target]): Boolean = {
+    targets.collect(collectStage).nonEmpty
+  }
+
+  def stageMatches(targets1: List[Target], targets2: List[Target]): Boolean = {
+    val stages1 = targets1.collect(collectStage).toSet
+    val stages2 = targets2.collect(collectStage).toSet
+    (stages1 intersect stages2).nonEmpty
+  }
+
+  def awsAccountMatches(targets1: List[Target], targets2: List[Target]): Boolean = {
+    val stages1 = targets1.collect(collectAwsAccount).toSet
+    val stages2 = targets2.collect(collectAwsAccount).toSet
+    (stages1 intersect stages2).nonEmpty
+  }
+
+  def stackMatches(targets1: List[Target], targets2: List[Target]): Boolean = {
+    val stages1 = targets1.collect(collectStack).toSet
+    val stages2 = targets2.collect(collectStack).toSet
+    (stages1 intersect stages2).nonEmpty
+  }
+
+  def appMatches(targets1: List[Target], targets2: List[Target]): Boolean = {
+    val stages1 = targets1.collect(collectApp).toSet
+    val stages2 = targets2.collect(collectApp).toSet
+    (stages1 intersect stages2).nonEmpty
+  }
+}

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
@@ -4,10 +4,14 @@ import com.gu.anghammarad.models._
 
 
 object Targets {
-  private val collectAwsAccount: PartialFunction[Target, AwsAccount] = { case a @ AwsAccount(_) => a }
-  private val collectStack: PartialFunction[Target, Stack] = { case s @ Stack(_) => s }
-  private val collectApp: PartialFunction[Target, App] = { case a @ App(_) => a }
-  private val collectStage: PartialFunction[Target, Stage] = { case s @ Stage(_) => s }
+  private val collectAwsAccount: PartialFunction[Target, AwsAccount] =
+    { case a @ AwsAccount(_) => a }
+  private val collectStack: PartialFunction[Target, Stack] =
+    { case s @ Stack(_) => s }
+  private val collectApp: PartialFunction[Target, App] =
+    { case a @ App(_) => a }
+  private val collectStage: PartialFunction[Target, Stage] =
+    { case s @ Stage(_) => s }
 
   def normaliseStages(targets: List[Target]): List[Target] = {
     if (includesStage(targets)) targets

--- a/anghammarad/src/test/resources/contacts-integration-fixture.json
+++ b/anghammarad/src/test/resources/contacts-integration-fixture.json
@@ -1,0 +1,77 @@
+{
+  "emailDomain": "example.com",
+  "mappings": [
+    {
+      "target": {
+        "Stack": "stack1"
+      },
+      "contacts": {
+        "email": "stack1.email",
+        "hangouts": "stack1.channel"
+      }
+    },
+    {
+      "target": {
+        "AwsAccount": "stack2"
+      },
+      "contacts": {
+        "email": "stack2.email"
+      }
+    },
+    {
+      "target": {
+        "App": "app1"
+      },
+      "contacts": {
+        "email": "app1.email",
+        "hangouts": "app1.channel"
+      }
+    },
+    {
+      "target": {
+        "Stack": "stack2",
+        "App": "app1"
+      },
+      "contacts": {
+        "email": "stack2.app1.email"
+      }
+    },
+    {
+      "target": {
+        "AwsAccount": "123456789"
+      },
+      "contacts": {
+        "email": "123456789.email"
+      }
+    },
+    {
+      "target": {
+        "AwsAccount": "111111111"
+      },
+      "contacts": {
+        "email": "111111111.email"
+      }
+    },
+    {
+      "target": {
+        "AwsAccount": "123456789",
+        "Stack": "stack2",
+        "App": "app2"
+      },
+      "contacts": {
+        "email": "app2.email"
+      }
+    },
+    {
+      "target": {
+        "AwsAccount": "123456789",
+        "Stack": "stack2",
+        "App": "app2",
+        "Stage": "CODE"
+      },
+      "contacts": {
+        "email": "app2.CODE.email"
+      }
+    }
+  ]
+}

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -125,10 +125,18 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
         resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
       }
 
-      "will not choose a mapping with a more specific requirement than has been targeted" in {
+      "will not choose a mapping with a more specific requirement than has been targeted (app)" in {
         val targets = List(AwsAccount("123456789"), Stack("stack"))
         val mappings = List(
           Mapping(List(AwsAccount("123456789"), Stack("stack"), App("app")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).isFailure shouldBe true
+      }
+
+      "will not choose a mapping with a more specific requirement than has been targeted (stack)" in {
+        val targets = List(AwsAccount("123456789"))
+        val mappings = List(
+          Mapping(List(AwsAccount("123456789"), Stack("stack")), List(emailAddress))
         )
         resolveTargetContacts(targets, mappings).isFailure shouldBe true
       }
@@ -146,7 +154,7 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
         val targets = List(Stack("stack"))
         val mappings = List(
           Mapping(List(AwsAccount("123456789"), Stack("stack")), List(emailAddress)),
-          Mapping(List(Stack("stack"), App("app2")), List(hangoutsRoom))
+          Mapping(List(Stack("stack"), App("app")), List(hangoutsRoom))
         )
         resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
       }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -12,112 +12,6 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
   val hangoutsRoom = HangoutsRoom("webhook")
 
   "resolveTargetContacts" - {
-    "resolves an exact match" in {
-      val targets = List(App("app"))
-      val mappings = List(Mapping(
-        List(App("app")),
-        List(emailAddress)
-      ))
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
-    }
-
-    "fails to resolve ambiguous exact matches" in {
-      val targets = List(App("app"))
-      val mappings = List(
-        Mapping(List(App("app")), List(emailAddress)),
-        Mapping(List(App("app")), List(hangoutsRoom))
-      )
-      resolveTargetContacts(targets, mappings).isFailure shouldEqual true
-    }
-
-    "finds multiple contacts for an exact match" in {
-      val targets = List(App("app"))
-      val mappings = List(Mapping(
-        List(App("app")),
-        List(emailAddress, hangoutsRoom)
-      ))
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress, hangoutsRoom)
-    }
-
-    "finds exact match among other mappings" in {
-      val targets = List(App("app1"))
-      val mappings = List(
-        Mapping(List(App("app1")), List(emailAddress)),
-        Mapping(List(Stack("stack1"), App("app2")), List(hangoutsRoom))
-      )
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
-    }
-
-    "chooses exact match over a partial match" in {
-      val targets = List(App("app1"))
-      val mappings = List(
-        Mapping(List(App("app1")), List(emailAddress)),
-        Mapping(List(Stack("stack1"), App("app1")), List(hangoutsRoom))
-      )
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
-    }
-
-    "resolves a more complex exact match" in {
-      val targets = List(Stack("stack"), Stage("stage"), App("app"))
-      val mappings = List(Mapping(
-        List(Stack("stack"), Stage("stage"), App("app")),
-        List(emailAddress)
-      ))
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
-    }
-
-    "chooses a complex exact match over a simple partial match" in {
-      val targets = List(Stack("stack"), Stage("stage"), App("app"))
-      val mappings = List(
-        Mapping(List(Stack("stack"), Stage("stage"), App("app")), List(emailAddress)),
-        Mapping(List(App("app")), List(hangoutsRoom))
-      )
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
-    }
-
-    "resolves a partial match" in {
-      val targets = List(App("app"))
-      val mappings = List(
-        Mapping(List(Stack("stack"), App("app")), List(emailAddress))
-      )
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
-    }
-
-    "resolves a complex partial match" in {
-      val targets = List(Stack("stack"), App("app"))
-      val mappings = List(
-        Mapping(List(Stack("stack"), App("app"), AwsAccount("123456789")), List(emailAddress))
-      )
-      resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
-    }
-
-    "fails to resolve from ambiguous partial matches" in {
-      val targets = List(Stack("stack"))
-      val mappings = List(
-        Mapping(List(Stack("stack"), App("app1")), List(emailAddress)),
-        Mapping(List(Stack("stack"), App("app2")), List(emailAddress))
-      )
-      resolveTargetContacts(targets, mappings).isFailure shouldEqual true
-    }
-
-    "fails to resolve from ambiguous complex partial matches" in {
-      val targets = List(Stack("stack"), Stage("PROD"))
-      val mappings = List(
-        Mapping(List(Stack("stack"), Stage("PROD"), App("app1")), List(emailAddress)),
-        Mapping(List(Stack("stack"), Stage("PROD"), App("app2")), List(emailAddress))
-      )
-      resolveTargetContacts(targets, mappings).isFailure shouldEqual true
-    }
-
-    "fails to resolve from ambiguous partial matches of different complexity (does not pick the closest match)" in {
-      val targets = List(Stack("stack"))
-      val mappings = List(
-        Mapping(List(Stack("stack"), App("app1")), List(emailAddress)),
-        Mapping(List(AwsAccount("123456789"), Stack("stack"), App("app2")), List(emailAddress))
-      )
-      resolveTargetContacts(targets, mappings).isFailure shouldEqual true
-    }
-
     "cannot resolve from empty mappings" in {
       val targets = List(Stack("stack"))
       val mappings = Nil
@@ -134,12 +28,309 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
       resolveTargetContacts(targets, mappings).isFailure shouldEqual true
     }
 
-    "fails to resolve a partially missing target" in {
-      val targets = List(Stack("stack"), App("app1"))
-      val mappings = List(
-        Mapping(List(App("app1")), List(emailAddress))
-      )
-      resolveTargetContacts(targets, mappings).isFailure shouldEqual true
+    "chooses an exact match, if it exists" - {
+      "chooses exact app match" in {
+        val targets = List(App("app"))
+        val mappings = List(
+          Mapping(List(App("app")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "finds multiple contacts for an exact match" in {
+        val targets = List(App("app"))
+        val mappings = List(
+          Mapping(List(App("app")), List(emailAddress, hangoutsRoom))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress, hangoutsRoom)
+      }
+
+      "finds exact match among other mappings" in {
+        val targets = List(App("app1"))
+        val mappings = List(
+          Mapping(List(App("app1")), List(emailAddress)),
+          Mapping(List(Stack("stack1"), App("app2")), List(hangoutsRoom))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "chooses exact app match over a partial match" in {
+        val targets = List(App("app1"))
+        val mappings = List(
+          Mapping(List(App("app1")), List(emailAddress)),
+          Mapping(List(Stack("stack1"), App("app1")), List(hangoutsRoom))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "chooses exact stack match over a partial match" in {
+        val targets = List(Stack("stack1"))
+        val mappings = List(
+          Mapping(List(Stack("stack1")), List(emailAddress)),
+          Mapping(List(Stack("stack1"), App("app1")), List(hangoutsRoom))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "chooses exact AWS account match over a partial match" in {
+        val targets = List(AwsAccount("123456789"))
+        val mappings = List(
+          Mapping(List(AwsAccount("123456789")), List(emailAddress)),
+          Mapping(List(AwsAccount("123456789"), App("app1")), List(hangoutsRoom))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "resolves a more complex exact match" in {
+        val targets = List(Stack("stack"), Stage("stage"), App("app"))
+        val mappings = List(
+          Mapping(List(Stack("stack"), Stage("stage"), App("app")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "chooses a complex exact match over a simple partial match" in {
+        val targets = List(Stack("stack"), Stage("stage"), App("app"))
+        val mappings = List(
+          Mapping(List(Stack("stack"), Stage("stage"), App("app")), List(emailAddress)),
+          Mapping(List(App("app")), List(hangoutsRoom))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "fails to resolve ambiguous exact matches" in {
+        val targets = List(App("app"))
+        val mappings = List(
+          Mapping(List(App("app")), List(emailAddress)),
+          Mapping(List(App("app")), List(hangoutsRoom))
+        )
+        resolveTargetContacts(targets, mappings).isFailure shouldEqual true
+      }
+    }
+
+    "when targets are under-specified, searches for a match among more specific mappings" - {
+      "resolves a partial match" in {
+        val targets = List(App("app"))
+        val mappings = List(
+          Mapping(List(Stack("stack"), App("app")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "resolves a more complex partial match" in {
+        val targets = List(Stack("stack"), App("app"))
+        val mappings = List(
+          Mapping(List(AwsAccount("123456789"), Stack("stack"), App("app")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "fails to resolve from ambiguous partial matches" in {
+        val targets = List(Stack("stack"))
+        val mappings = List(
+          Mapping(List(Stack("stack"), App("app1")), List(emailAddress)),
+          Mapping(List(Stack("stack"), App("app2")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).isFailure shouldEqual true
+      }
+
+      "resolves ambiguous incomplete partial matches where target hierarchy can disambiguate mappings" in {
+        val targets = List(Stack("stack"))
+        val mappings = List(
+          Mapping(List(AwsAccount("123456789"), Stack("stack")), List(emailAddress)),
+          Mapping(List(Stack("stack"), App("app2")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+      }
+
+      "fails to resolve from ambiguous partial matches with equal specificity" in {
+        val targets = List(AwsAccount("123456789"), Stack("stack"))
+        val mappings = List(
+          Mapping(List(AwsAccount("123456789"), Stack("stack"), App("app1")), List(emailAddress)),
+          Mapping(List(AwsAccount("123456789"), Stack("stack"), App("app2")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).isFailure shouldEqual true
+      }
+
+      "fails to resolve from ambiguous partial matches of different complexity (does not pick the closest match)" in {
+        val targets = List(Stack("stack"))
+        val mappings = List(
+          Mapping(List(Stack("stack"), App("app1")), List(emailAddress)),
+          Mapping(List(AwsAccount("123456789"), Stack("stack"), App("app2")), List(emailAddress))
+        )
+        resolveTargetContacts(targets, mappings).isFailure shouldEqual true
+      }
+    }
+
+    "when target is over-specified, uses hierarchy of targets to identify a match from less specific mappings" - {
+      "app is most specific then both stack and Aws Account" - {
+        "chooses app over stack" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack"), App("app1"))
+          val mappings = List(
+            Mapping(List(App("app1")), List(emailAddress)),
+            Mapping(List(Stack("stack")), List(hangoutsRoom))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "chooses app over AWS account" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack"), App("app1"))
+          val mappings = List(
+            Mapping(List(App("app1")), List(emailAddress)),
+            Mapping(List(AwsAccount("123456789")), List(hangoutsRoom))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "chooses just app over a mapping with both stack and AWS account" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack"), App("app1"))
+          val mappings = List(
+            Mapping(List(App("app1")), List(emailAddress)),
+            Mapping(List(Stack("stack"), AwsAccount("123456789")), List(hangoutsRoom))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "chooses partial match with app over partial match with same number of less specific targets" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack"), App("app1"))
+          val mappings = List(
+            Mapping(List(App("app1"), Stack("stack")), List(emailAddress)),
+            Mapping(List(Stack("stack"), AwsAccount("123456789")), List(hangoutsRoom))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "does not resolve a partial app match if another target conflicts" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack1"), App("app1"))
+          val mappings = List(
+            Mapping(List(Stack("stack2"), App("app1")), List(hangoutsRoom))
+          )
+          resolveTargetContacts(targets, mappings).isFailure shouldBe true
+        }
+
+        "falls back to less specific partial match where app matches but other targets conflict" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack1"), App("app1"))
+          val mappings = List(
+            Mapping(List(Stack("stack1"), AwsAccount("123456789")), List(emailAddress)),
+            Mapping(List(Stack("stack2"), App("app1")), List(hangoutsRoom))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+      }
+
+      "stack is more specific than account, less than app" - {
+        "chooses stack over AWS account" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack"), App("app1"))
+          val mappings = List(
+            Mapping(List(Stack("stack")), List(emailAddress)),
+            Mapping(List(AwsAccount("123456789")), List(hangoutsRoom))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "does not resolve a partial stack match if another target conflicts" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack"), App("app1"))
+          val mappings = List(
+            Mapping(List(AwsAccount("111111111"), Stack("stack")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).isFailure shouldBe true
+        }
+
+        "falls back to less specific partial match where stack matches but other targets conflict" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack1"), App("app1"))
+          val mappings = List(
+            Mapping(List(AwsAccount("123456789")), List(hangoutsRoom)),
+            Mapping(List(Stack("stack1"), AwsAccount("111111111")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+      }
+
+      "AWS Account is less specific than app and stack" - {
+        "does not resolve a partial AWS Account match if another target conflicts" in {
+          val targets = List(AwsAccount("123456789"), Stack("stack1"), App("app1"))
+          val mappings = List(
+            Mapping(List(AwsAccount("123456789"), Stack("stack2")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).isFailure shouldBe true
+        }
+      }
+    }
+
+    "handles stage correctly" - {
+      "empty stage is assumed to be PROD" - {
+        "over-specified partial match with empty stage in target matches empty stage in mapping" in {
+          val targets = List(Stack("stack"), App("app"))
+          val mappings = List(
+            Mapping(List(App("app")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "under-specified partial match with empty stage in target matches empty stage in mapping" in {
+          val targets = List(App("app"))
+          val mappings = List(
+            Mapping(List(Stack("stack"), App("app")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "explicit PROD in target matches empty stage in mapping" in {
+          val targets = List(Stack("stack"), Stage("PROD"))
+          val mappings = List(
+            Mapping(List(Stack("stack")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+
+        "empty stage in target matches explicit PROD in mapping" in {
+          val targets = List(Stack("stack"))
+          val mappings = List(
+            Mapping(List(Stack("stack"), Stage("PROD")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+      }
+
+      "if a non-empty non-PROD stage is targeted, mappings without that stage will not be matched" - {
+        "fails to match if there is no matching non-PROD stage" in {
+          val targets = List(Stack("stack"), Stage("stage"))
+          val mappings = List(
+            Mapping(List(Stack("stack")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).isFailure shouldBe true
+        }
+      }
+
+      "if a stage is targeted, matches exact mappings for that stage" - {
+        "fails to match if there is no matching non-PROD stage" in {
+          val targets = List(Stack("stack"), Stage("stage"))
+          val mappings = List(
+            Mapping(List(Stack("stack"), Stage("stage")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+      }
+
+      "if a stage is targeted, matches over-specified mappings for that stage" - {
+        "fails to match if there is no matching non-PROD stage" in {
+          val targets = List(Stack("stack"), App("app"), Stage("stage"))
+          val mappings = List(
+            Mapping(List(App("app"), Stage("stage")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+      }
+
+      "if a stage is targeted, matches under-specified mappings for that stage" - {
+        "fails to match if there is no matching non-PROD stage" in {
+          val targets = List(App("app"), Stage("stage"))
+          val mappings = List(
+            Mapping(List(Stack("stack"), App("app"), Stage("stage")), List(emailAddress))
+          )
+          resolveTargetContacts(targets, mappings).success shouldEqual List(emailAddress)
+        }
+      }
     }
 
     "fails to resolve a complex partially missing target" in {

--- a/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
@@ -1,0 +1,148 @@
+package com.gu.anghammarad
+
+import com.gu.anghammarad.models._
+import org.scalatest.{FreeSpec, Matchers}
+
+
+class TargetsTest extends FreeSpec with Matchers {
+  import com.gu.anghammarad.Targets._
+
+  "normaliseStages" - {
+    "adds PROD stage to a list of targets that does not include stage" in {
+      normaliseStages(List(AwsAccount("123456789"), App("app"))) should contain(Stage("PROD"))
+    }
+
+    "does not change a list of targets that already includes a stage" in {
+      val targets = List(Stage("stage"), AwsAccount("123456789"), App("app"))
+      normaliseStages(targets) shouldEqual targets
+    }
+  }
+
+  "includesAwsAccount" - {
+    "returns false if AwsAccount is enquired about and not present" in {
+      includesAwsAccount(List(App("app"))) shouldBe false
+    }
+
+    "returns true if AwsAccount is enquired about and present" in {
+      includesAwsAccount(List(AwsAccount("123456789"), App("app"))) shouldBe true
+    }
+  }
+
+  "includesStack" - {
+    "returns false if Stack is enquired about and not present" in {
+      includesStack(List(App("app"))) shouldBe false
+    }
+
+    "returns true if Stack is enquired about and present" in {
+      includesStack(List(Stack("stack"), App("app"))) shouldBe true
+    }
+  }
+
+  "includesApp" - {
+    "returns false if App is enquired about and not present" in {
+      includesApp(List(Stack("stack"))) shouldBe false
+    }
+
+    "returns true if App is enquired about and present" in {
+      includesApp(List(App("app"), Stack("stack"))) shouldBe true
+    }
+  }
+
+  "includesStage" - {
+    "returns false if Stage is enquired about and not present" in {
+      includesStage(List(App("app"))) shouldBe false
+    }
+
+    "returns true if Stage is enquired about and present" in {
+      includesStage(List(Stage("stage"), App("app"))) shouldBe true
+    }
+  }
+
+  "stageMatches" - {
+    "returns true if the stages match" in {
+      stageMatches(List(Stage("PROD")), List(Stage("PROD"))) shouldBe true
+    }
+
+    "returns true if the stages match among other targets" in {
+      stageMatches(List(App("app"), Stage("PROD")), List(Stage("PROD"), Stack("stack"))) shouldBe true
+    }
+
+    "returns false if the stages do not match" in {
+      stageMatches(List(Stage("stage")), List(Stage("PROD"))) shouldBe false
+    }
+
+    "returns false if the stages do not match among other targets" in {
+      stageMatches(List(App("app"), Stage("stage")), List(Stage("PROD"), Stack("stack"))) shouldBe false
+    }
+
+    "returns true if multiple stages are present as long as there is an overlap" in {
+      stageMatches(List(Stage("stage1"), Stage("stage2")), List(Stage("stage1"))) shouldBe true
+    }
+  }
+
+  "awsAccountMatches" - {
+    "returns true if the AWS Accounts match" in {
+      awsAccountMatches(List(AwsAccount("123456789")), List(AwsAccount("123456789"))) shouldBe true
+    }
+
+    "returns true if the AWS Accounts match among other targets" in {
+      awsAccountMatches(List(App("app"), AwsAccount("123456789")), List(AwsAccount("123456789"), Stack("stack"))) shouldBe true
+    }
+
+    "returns false if the AWS Accounts do not match" in {
+      awsAccountMatches(List(AwsAccount("111111111")), List(AwsAccount("123456789"))) shouldBe false
+    }
+
+    "returns false if the AWS Accounts do not match among other targets" in {
+      awsAccountMatches(List(App("app"), Stage("stage")), List(AwsAccount("123456789"), Stack("stack"))) shouldBe false
+    }
+
+    "returns true if multiple AWS Accounts are present as long as there is an overlap" in {
+      awsAccountMatches(List(AwsAccount("123456789"), AwsAccount("111111111")), List(AwsAccount("123456789"))) shouldBe true
+    }
+  }
+
+  "stackMatches" - {
+    "returns true if the Stacks match" in {
+      stackMatches(List(Stack("stack")), List(Stack("stack"))) shouldBe true
+    }
+
+    "returns true if the Stacks match among other targets" in {
+      stackMatches(List(App("app"), Stack("stack")), List(AwsAccount("123456789"), Stack("stack"))) shouldBe true
+    }
+
+    "returns false if the Stacks do not match" in {
+      stackMatches(List(Stack("stack1")), List(Stack("stack2"))) shouldBe false
+    }
+
+    "returns false if the Stacks do not match among other targets" in {
+      stackMatches(List(App("app"), Stack("stack1")), List(Stack("stack2"), AwsAccount("123456789"))) shouldBe false
+    }
+
+    "returns true if multiple Stacks are present as long as there is an overlap" in {
+      stackMatches(List(Stack("stack1"), Stack("stack2")), List(Stack("stack1"))) shouldBe true
+    }
+  }
+
+  "appMatches" - {
+    "returns true if the Apps match" in {
+      appMatches(List(App("app")), List(App("app"))) shouldBe true
+    }
+
+    "returns true if the Apps match among other targets" in {
+      appMatches(List(App("app"), Stack("stack")), List(AwsAccount("123456789"), App("app"))) shouldBe true
+    }
+
+    "returns false if the Apps do not match" in {
+      appMatches(List(App("app1")), List(App("app2"))) shouldBe false
+    }
+
+    "returns false if the Apps do not match among other targets" in {
+      appMatches(List(Stack("stack"), App("app1")), List(App("app2"), AwsAccount("123456789"))) shouldBe false
+    }
+
+    "returns true if multiple Apps are present as long as there is an overlap" in {
+      appMatches(List(App("app1"), App("app2")), List(App("app1"))) shouldBe true
+    }
+  }
+}

--- a/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
@@ -145,4 +145,45 @@ class TargetsTest extends FreeSpec with Matchers {
       appMatches(List(App("app1"), App("app2")), List(App("app1"))) shouldBe true
     }
   }
+
+  "sortMappingsByTargets" - {
+    val expected = List(EmailAddress("expected"))
+    val unexpected = List(EmailAddress("unexpected"))
+
+    "matching app goes before matching stage and aws account" in {
+      val targets = List(App("app"), Stack("stack"), AwsAccount("123456789"))
+      val mappings = List(
+        Mapping(List(App("app")), expected),
+        Mapping(List(Stack("stack"), AwsAccount("123456789")), unexpected)
+      )
+      sortMappingsByTargets(targets, mappings).head.contacts shouldEqual expected
+    }
+
+    "non-matching app goes after matching stage and aws account" in {
+      val targets = List(App("app1"), Stack("stack"), AwsAccount("123456789"))
+      val mappings = List(
+        Mapping(List(App("app2")), unexpected),
+        Mapping(List(Stack("stack"), AwsAccount("123456789")), expected)
+      )
+      sortMappingsByTargets(targets, mappings).head.contacts shouldEqual expected
+    }
+
+    "matching stack goes before matching aws account" in {
+      val targets = List(Stack("stack"), AwsAccount("123456789"))
+      val mappings = List(
+        Mapping(List(Stack("stack")), expected),
+        Mapping(List(AwsAccount("123456789")), unexpected)
+      )
+      sortMappingsByTargets(targets, mappings).head.contacts shouldEqual expected
+    }
+
+    "non-matching stack goes after matching aws account" in {
+      val targets = List(Stack("stack1"), AwsAccount("123456789"))
+      val mappings = List(
+        Mapping(List(Stack("stack2")), unexpected),
+        Mapping(List(AwsAccount("123456789")), expected)
+      )
+      sortMappingsByTargets(targets, mappings).head.contacts shouldEqual expected
+    }
+  }
 }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/testutils/TryValues.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/testutils/TryValues.scala
@@ -9,7 +9,7 @@ trait TryValues {
     def success: T = tried match {
       case Success(t) => t
       case Failure(err) =>
-        throw new TestFailedException("Could not get successful value from failed Try", err, 10)
+        throw new TestFailedException(s"Could not get successful value from failed Try (${err.getMessage})", err, 10)
     }
 
     def failure: Throwable = tried match {


### PR DESCRIPTION
The original logic was very simplified, and now we're actually integrating a service we see that it was well short of what is required. This PR introduces "proper" contact resolution, that behaves the way people expect.

This works using a hierarchy of targets. App matches are more important than Stack matches, which are more important that AwsAccount matches. Stage must always match and is assumed to be PROD if it is omitted.

If there's an exact match between targets and a mapping then life is easy, but that won't generally be the case. We want to be able to send a message to `App("myapp")`. We'd also like to be able to send a message from an application that derives all the targets from its tags (e.g. `App("myapp")`, `Stack("mystack")`, `AwsAccount("account-id")`, `Stage("STAGE")`). In both case it should route messages to the "correct place". The correct place would be an exact (/close) match if it exists in the configuration, but if it hasn't been fully specified we'd still expect it to be able to send a message to the best valid match (App if that exists, falling back to Stack and then AwsAccount).

It is pretty complicated, but the logic ends up being reasonable and there are **a lot** of tests to capture all the edge cases. It also has a few "integration" tests that simulate more realistic invocations against a more realistic mapping configuration.

Sorry this is so complex, and such a large PR. Maybe start with the integration test section of ContactsTest and then look at the implementation.

This logic basically *is* Anghammarad. Sending messages to a webhook is easy, the value of a department-wide service is its ability to send messages to the correct people.