### PR TITLE
Adds "preferred" to requested channels

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/Anghammarad.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Anghammarad.scala
@@ -12,11 +12,11 @@ object Anghammarad {
     for {
       contacts <- Contacts.resolveTargetContacts(notification.target, config.mappings)
       // get contacts for desired channels (if possible)
-      channelContacts = Contacts.resolveContactsForChannels(contacts, notification.channel)
-      // make messages
-      channelMessages = Messages.channelMessages(notification)
+      channelContacts <- Contacts.resolveContactsForChannels(contacts, notification.channel)
       // find contacts for each message
-      toSend <- Contacts.contactsForMessages(channelMessages, channelContacts)
+      contacts <- Contacts.contactsForMessage(notification.channel, channelContacts)
+      // address messages
+      toSend = Contacts.createMessages(notification, contacts)
       // send resolved notifications
       result <- SendMessages.sendAll(config, toSend)
     } yield toSend

--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
@@ -17,24 +17,6 @@ object Messages {
   private[anghammarad] val mdParser = Parser.builder(mdOptions).build
   private[anghammarad] val mdRenderer = HtmlRenderer.builder(mdOptions).build()
 
-  def channelMessages(notification: Notification): List[(Channel, Message)] = {
-    notification.channel match {
-      case Email =>
-        List(
-          Email -> emailMessage(notification)
-        )
-      case HangoutsChat =>
-        List(
-          HangoutsChat -> hangoutMessage(notification)
-        )
-      case All =>
-        List(
-          Email -> emailMessage(notification),
-          HangoutsChat -> hangoutMessage(notification)
-        )
-    }
-  }
-
   def emailMessage(notification: Notification): EmailMessage = {
     val (markdown, plaintext) =
       if (notification.actions.isEmpty) {

--- a/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
@@ -73,6 +73,8 @@ object Serialization {
       case "email" => Success(Email)
       case "hangouts" => Success(HangoutsChat)
       case "all" => Success(All)
+      case "prefer email" => Success(Preferred(Email))
+      case "prefer hangouts" => Success(Preferred(HangoutsChat))
       case _ => Fail(s"Parsing error: Unable to match RequestedChannel to known options")
     }
   }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -468,7 +468,7 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
       resolveContactsForChannels(List(emailAddress, hangoutsRoom), Preferred(Email)).success shouldEqual List(Email -> emailAddress)
     }
 
-    "if email is preferred and absent, returns webhhok" in {
+    "if email is preferred and absent, returns webhook" in {
       resolveContactsForChannels(List(hangoutsRoom), Preferred(Email)).success shouldEqual List(HangoutsChat -> hangoutsRoom)
     }
 

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -444,59 +444,69 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
   }
 
   "resolveContactsForChannels" - {
-    "if no contacts are provided, finds no channels" in {
-      resolveContactsForChannels(Nil, All) shouldEqual Nil
+    "if no contacts are provided, fails because it cannot find any channels" in {
+      resolveContactsForChannels(Nil, All).isFailure shouldBe true
     }
 
-    "does not find a contact from a different channel" in {
-      resolveContactsForChannels(List(emailAddress), HangoutsChat) shouldEqual Nil
+    "fails if a requested channel is not available" in {
+      resolveContactsForChannels(List(emailAddress), HangoutsChat).isFailure shouldBe true
     }
 
     "finds a contact from a relevant channel" in {
-      resolveContactsForChannels(List(emailAddress), Email) shouldEqual List(Email -> emailAddress)
+      resolveContactsForChannels(List(emailAddress), Email).success shouldEqual List(Email -> emailAddress)
     }
 
     "if multiple channels are requested, returns as many as it can" in {
-      resolveContactsForChannels(List(emailAddress), All) shouldEqual List(Email -> emailAddress)
+      resolveContactsForChannels(List(emailAddress), All).success shouldEqual List(Email -> emailAddress)
     }
 
     "returns all matching contacts when All is requested" in {
-      resolveContactsForChannels(List(emailAddress, hangoutsRoom), All) shouldEqual List(Email -> emailAddress, HangoutsChat -> hangoutsRoom)
+      resolveContactsForChannels(List(emailAddress, hangoutsRoom), All).success shouldEqual List(Email -> emailAddress, HangoutsChat -> hangoutsRoom)
+    }
+
+    "if email is preferred and present, returns email" in {
+      resolveContactsForChannels(List(emailAddress, hangoutsRoom), Preferred(Email)).success shouldEqual List(Email -> emailAddress)
+    }
+
+    "if email is preferred and absent, returns webhhok" in {
+      resolveContactsForChannels(List(hangoutsRoom), Preferred(Email)).success shouldEqual List(HangoutsChat -> hangoutsRoom)
+    }
+
+    "if hangouts is preferred and present, returns webhook" in {
+      resolveContactsForChannels(List(emailAddress, hangoutsRoom), Preferred(HangoutsChat)).success shouldEqual List(HangoutsChat -> hangoutsRoom)
+    }
+
+    "if webhook is preferred and absent, returns email" in {
+      resolveContactsForChannels(List(emailAddress), Preferred(HangoutsChat)).success shouldEqual List(Email -> emailAddress)
     }
   }
 
-  "contactsForMessages" - {
-    "returns an empty list if there were no contacts and no messages" in {
-      contactsForMessages(Nil, Nil).success shouldEqual Nil
+  "contactsForMessage" - {
+    "if there were no contacts and no messages it fails to find contacts and fails" in {
+      contactsForMessage(All, Nil).isFailure shouldEqual true
     }
 
     "returns a failure if we could not find a contact for a message" in {
-      contactsForMessages(List(Email -> email), Nil).isFailure shouldEqual true
+      contactsForMessage(Email, Nil).isFailure shouldEqual true
     }
 
-    "returns a failure if we could only find a contact for one channel" in {
-      contactsForMessages(
-        List(Email -> email, HangoutsChat -> hangoutMessage),
-        List(Email -> emailAddress)
-      ).isFailure shouldEqual true
+    "returns a failure if the requested channel is not available" in {
+      val result = contactsForMessage(HangoutsChat, List(Email -> emailAddress))
+      result.isFailure shouldEqual true
     }
 
     "returns the contact for a message, if present" in {
-      val result = contactsForMessages(List(Email -> email), List(Email -> emailAddress)).success
-      result shouldEqual List(email -> emailAddress)
+      contactsForMessage(Email, List(Email -> emailAddress)).success shouldEqual List(Email -> emailAddress)
     }
 
     "returns the contact for the correct channel, if multiple are present" in {
-      val result = contactsForMessages(List(Email -> email), List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)).success
-      result shouldEqual List(email -> emailAddress)
+      val result = contactsForMessage(Email, List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)).success
+      result shouldEqual List(Email -> emailAddress)
     }
 
     "matches multiple messages with their contacts" in {
-      val result = contactsForMessages(
-        List(Email -> email, HangoutsChat -> hangoutMessage),
-        List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)
-      ).success
-      result shouldEqual List(email -> emailAddress, hangoutMessage -> hangoutsRoom)
+      val result = contactsForMessage(All, List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)).success
+      result shouldEqual List(Email -> emailAddress, HangoutsChat -> hangoutsRoom)
     }
   }
 }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
@@ -74,6 +74,8 @@ class SerializationTest extends FreeSpec with Matchers with EitherValues with Tr
       Serialization.parseRequestedChannel("email").success shouldEqual Email
       Serialization.parseRequestedChannel("hangouts").success  shouldEqual HangoutsChat
       Serialization.parseRequestedChannel("all").success  shouldEqual All
+      Serialization.parseRequestedChannel("prefer email").success  shouldEqual Preferred(Email)
+      Serialization.parseRequestedChannel("prefer hangouts").success  shouldEqual Preferred(HangoutsChat)
     }
 
     "will return a failure if no match is found" in {

--- a/client/src/main/scala/com/gu/anghammarad/Json.scala
+++ b/client/src/main/scala/com/gu/anghammarad/Json.scala
@@ -11,6 +11,8 @@ object Json extends StrictLogging {
       case Email => "email"
       case HangoutsChat => "hangouts"
       case All => "all"
+      case Preferred(Email) => "prefer email"
+      case Preferred(HangoutsChat) => "prefer hangouts"
     }
     s"""{
        |  "message":${quoteJson(message)},
@@ -23,16 +25,13 @@ object Json extends StrictLogging {
 
   private[anghammarad] def targetJson(targets: List[Target]): String = {
     def targetJsonString(key: String, value: String) = s""""$key":${quoteJson(value)}"""
-    val kvpairs = targets.map (target => {
-      target match {
-        case Stack(stack) => targetJsonString("Stack", stack)
-        case Stage(stage) => targetJsonString("Stage", stage)
-        case App(app) => targetJsonString("App", app)
-        case AwsAccount(awsAccount) => targetJsonString("AwsAccount", awsAccount)
-        case _ => ""
-      }
-    }
-    ).mkString(",")
+    val kvpairs = targets.map {
+      case Stack(stack) => targetJsonString("Stack", stack)
+      case Stage(stage) => targetJsonString("Stage", stage)
+      case App(app) => targetJsonString("App", app)
+      case AwsAccount(awsAccount) => targetJsonString("AwsAccount", awsAccount)
+      case _ => ""
+    }.mkString(",")
     s"{$kvpairs}"
   }
 

--- a/common/src/main/scala/com/gu/anghammarad/models/models.scala
+++ b/common/src/main/scala/com/gu/anghammarad/models/models.scala
@@ -8,6 +8,7 @@ case class AwsAccount(awsAccount: String) extends Target
 
 sealed trait RequestedChannel
 case object All extends RequestedChannel
+case class Preferred(preferredChannel: Channel) extends RequestedChannel
 
 sealed trait Channel
 case object Email extends Channel with RequestedChannel


### PR DESCRIPTION
This is for when the source system would rather use a specific channel, but will take whatever is available if it is not.

Involved a bit of a refactor because the code could previously be strict about what was found. If we asked for Email and it wasn't there, that's a failure. Now it needs to be able to fall back to another channel so the "addressing" logic is now separate from the creation of messages. This is made manifest in the removal of `channelMessages` and the addition of a simpler `createMessages` function. `contactsForMessage` is now a little more complex becuase it has to handle the fallback in the `Preferred` cases.