### PR TITLE
Better client interface

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/Anghammarad.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Anghammarad.scala
@@ -12,11 +12,11 @@ object Anghammarad {
     for {
       contacts <- Contacts.resolveTargetContacts(notification.target, config.mappings)
       // get contacts for desired channels (if possible)
-      channelContacts = Contacts.resolveContactsForChannels(contacts, notification.channel)
-      // make messages
-      channelMessages = Messages.channelMessages(notification)
+      channelContacts <- Contacts.resolveContactsForChannels(contacts, notification.channel)
       // find contacts for each message
-      toSend <- Contacts.contactsForMessages(channelMessages, channelContacts)
+      contacts <- Contacts.contactsForMessage(notification.channel, channelContacts)
+      // address messages
+      toSend = Contacts.createMessages(notification, contacts)
       // send resolved notifications
       result <- SendMessages.sendAll(config, toSend)
     } yield toSend

--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
@@ -17,24 +17,6 @@ object Messages {
   private[anghammarad] val mdParser = Parser.builder(mdOptions).build
   private[anghammarad] val mdRenderer = HtmlRenderer.builder(mdOptions).build()
 
-  def channelMessages(notification: Notification): List[(Channel, Message)] = {
-    notification.channel match {
-      case Email =>
-        List(
-          Email -> emailMessage(notification)
-        )
-      case HangoutsChat =>
-        List(
-          HangoutsChat -> hangoutMessage(notification)
-        )
-      case All =>
-        List(
-          Email -> emailMessage(notification),
-          HangoutsChat -> hangoutMessage(notification)
-        )
-    }
-  }
-
   def emailMessage(notification: Notification): EmailMessage = {
     val (markdown, plaintext) =
       if (notification.actions.isEmpty) {

--- a/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
@@ -73,6 +73,8 @@ object Serialization {
       case "email" => Success(Email)
       case "hangouts" => Success(HangoutsChat)
       case "all" => Success(All)
+      case "prefer email" => Success(Preferred(Email))
+      case "prefer hangouts" => Success(Preferred(HangoutsChat))
       case _ => Fail(s"Parsing error: Unable to match RequestedChannel to known options")
     }
   }

--- a/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
@@ -63,7 +63,7 @@ object Serialization {
       channel <- parseRequestedChannel(rawChannel).toEither
       targets <- parseAllTargets(rawTargets).toEither
       actions <- rawActions.traverseT(parseAction).toEither
-    } yield Notification(sourceSystem, channel, targets, subject, message, actions)
+    } yield Notification(subject, message, actions, targets, channel, sourceSystem)
 
     parsingResult.toTry
   }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -444,59 +444,69 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
   }
 
   "resolveContactsForChannels" - {
-    "if no contacts are provided, finds no channels" in {
-      resolveContactsForChannels(Nil, All) shouldEqual Nil
+    "if no contacts are provided, fails because it cannot find any channels" in {
+      resolveContactsForChannels(Nil, All).isFailure shouldBe true
     }
 
-    "does not find a contact from a different channel" in {
-      resolveContactsForChannels(List(emailAddress), HangoutsChat) shouldEqual Nil
+    "fails if a requested channel is not available" in {
+      resolveContactsForChannels(List(emailAddress), HangoutsChat).isFailure shouldBe true
     }
 
     "finds a contact from a relevant channel" in {
-      resolveContactsForChannels(List(emailAddress), Email) shouldEqual List(Email -> emailAddress)
+      resolveContactsForChannels(List(emailAddress), Email).success shouldEqual List(Email -> emailAddress)
     }
 
     "if multiple channels are requested, returns as many as it can" in {
-      resolveContactsForChannels(List(emailAddress), All) shouldEqual List(Email -> emailAddress)
+      resolveContactsForChannels(List(emailAddress), All).success shouldEqual List(Email -> emailAddress)
     }
 
     "returns all matching contacts when All is requested" in {
-      resolveContactsForChannels(List(emailAddress, hangoutsRoom), All) shouldEqual List(Email -> emailAddress, HangoutsChat -> hangoutsRoom)
+      resolveContactsForChannels(List(emailAddress, hangoutsRoom), All).success shouldEqual List(Email -> emailAddress, HangoutsChat -> hangoutsRoom)
+    }
+
+    "if email is preferred and present, returns email" in {
+      resolveContactsForChannels(List(emailAddress, hangoutsRoom), Preferred(Email)).success shouldEqual List(Email -> emailAddress)
+    }
+
+    "if email is preferred and absent, returns webhhok" in {
+      resolveContactsForChannels(List(hangoutsRoom), Preferred(Email)).success shouldEqual List(HangoutsChat -> hangoutsRoom)
+    }
+
+    "if hangouts is preferred and present, returns webhook" in {
+      resolveContactsForChannels(List(emailAddress, hangoutsRoom), Preferred(HangoutsChat)).success shouldEqual List(HangoutsChat -> hangoutsRoom)
+    }
+
+    "if webhook is preferred and absent, returns email" in {
+      resolveContactsForChannels(List(emailAddress), Preferred(HangoutsChat)).success shouldEqual List(Email -> emailAddress)
     }
   }
 
-  "contactsForMessages" - {
-    "returns an empty list if there were no contacts and no messages" in {
-      contactsForMessages(Nil, Nil).success shouldEqual Nil
+  "contactsForMessage" - {
+    "if there were no contacts and no messages it fails to find contacts and fails" in {
+      contactsForMessage(All, Nil).isFailure shouldEqual true
     }
 
     "returns a failure if we could not find a contact for a message" in {
-      contactsForMessages(List(Email -> email), Nil).isFailure shouldEqual true
+      contactsForMessage(Email, Nil).isFailure shouldEqual true
     }
 
-    "returns a failure if we could only find a contact for one channel" in {
-      contactsForMessages(
-        List(Email -> email, HangoutsChat -> hangoutMessage),
-        List(Email -> emailAddress)
-      ).isFailure shouldEqual true
+    "returns a failure if the requested channel is not available" in {
+      val result = contactsForMessage(HangoutsChat, List(Email -> emailAddress))
+      result.isFailure shouldEqual true
     }
 
     "returns the contact for a message, if present" in {
-      val result = contactsForMessages(List(Email -> email), List(Email -> emailAddress)).success
-      result shouldEqual List(email -> emailAddress)
+      contactsForMessage(Email, List(Email -> emailAddress)).success shouldEqual List(Email -> emailAddress)
     }
 
     "returns the contact for the correct channel, if multiple are present" in {
-      val result = contactsForMessages(List(Email -> email), List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)).success
-      result shouldEqual List(email -> emailAddress)
+      val result = contactsForMessage(Email, List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)).success
+      result shouldEqual List(Email -> emailAddress)
     }
 
     "matches multiple messages with their contacts" in {
-      val result = contactsForMessages(
-        List(Email -> email, HangoutsChat -> hangoutMessage),
-        List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)
-      ).success
-      result shouldEqual List(email -> emailAddress, hangoutMessage -> hangoutsRoom)
+      val result = contactsForMessage(All, List(HangoutsChat -> hangoutsRoom, Email -> emailAddress)).success
+      result shouldEqual List(Email -> emailAddress, HangoutsChat -> hangoutsRoom)
     }
   }
 }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
@@ -134,7 +134,7 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
   }
 
   def testNotification(subject: String, message: String, actions: Action*): Notification = {
-    Notification("test", All, Nil, subject, message, actions.toList)
+    Notification(subject, message, actions.toList, Nil, All, "test")
   }
 
   /**
@@ -148,9 +148,12 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
     */
   "test end-to-end hangouts message" ignore {
     val notification = Notification(
-      "Testing", HangoutsChat, Nil, "Subject",
+      "Subject",
       "Mentions don't work in card messages yet.\nMessage *with* some **styles**!",
-      List(Action("CTA", "https://example.com/"), Action("Another CTA", "https://example.com/"))
+      List(Action("CTA", "https://example.com/"), Action("Another CTA", "https://example.com/")),
+      Nil,
+      HangoutsChat,
+      "Testing"
     )
     val message = Messages.hangoutMessage(notification)
     // println(message.cardJson)

--- a/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
@@ -19,12 +19,12 @@ class SerializationTest extends FreeSpec with Matchers with EitherValues with Tr
     val validJson = parse(validJsonString).right.value
 
     val expectedResult = Notification(
-      "Terry Pratchett",
-      Email,
-      List(Stack("postal-service"), App("clacks-overhead")),
       "GNU Terry Pratchett",
       "Words are important. And when there is a critical mass of them, they change the nature of the universe.",
-      List(Action("keep that name moving in the Overhead", "http://www.gnuterrypratchett.com/"))
+      List(Action("keep that name moving in the Overhead", "http://www.gnuterrypratchett.com/")),
+      List(Stack("postal-service"), App("clacks-overhead")),
+      Email,
+      "Terry Pratchett"
     )
 
     "parseNotification" - {

--- a/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
@@ -74,6 +74,8 @@ class SerializationTest extends FreeSpec with Matchers with EitherValues with Tr
       Serialization.parseRequestedChannel("email").success shouldEqual Email
       Serialization.parseRequestedChannel("hangouts").success  shouldEqual HangoutsChat
       Serialization.parseRequestedChannel("all").success  shouldEqual All
+      Serialization.parseRequestedChannel("prefer email").success  shouldEqual Preferred(Email)
+      Serialization.parseRequestedChannel("prefer hangouts").success  shouldEqual Preferred(HangoutsChat)
     }
 
     "will return a failure if no match is found" in {

--- a/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
+++ b/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
@@ -21,7 +21,7 @@ object Anghammarad {
     * @param channel      The notification channel you'd like to use
     * @param sourceSystem The system sending the notification (your system)
     * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
-    * @param client       The SNS client that should be used to add your notification to the topic
+    * @param client       The SNS client used to add your notification to the topic (if omitted, a default is used)
     * @return             Future containing the resulting SNS Message ID
     */
   def notify(subject: String, message: String, actions: List[Action], target: List[Target], channel: RequestedChannel,
@@ -36,6 +36,7 @@ object Anghammarad {
 
   /**
     * Sends a notification using Anghammarad.
+    * This uses a default SNS client with a default implementation of the credentials provider.
     *
     * @param notification The notification to send
     * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
@@ -55,7 +56,7 @@ object Anghammarad {
     *
     * @param notification The notification to send
     * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
-    * @param client       The SNS client that should be used to add your notification to the topic
+    * @param client       The SNS client used to add your notification to the topic
     * @return             Future containing the resulting SNS Message ID
     */
   def notify(notification: Notification, topicArn: String, client: AmazonSNSAsync)

--- a/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
+++ b/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
@@ -10,28 +10,60 @@ import scala.concurrent.{ExecutionContext, Future}
 
 
 object Anghammarad {
+  lazy private val defaultClient = AWS.snsClient(AWS.credentialsProvider())
   /**
     * Sends a notification using Anghammarad.
     *
     * @param subject      Used for the subject in emails and the heading of hangouts chat notifications
     * @param message      The message body. Supports markdown, but support differs between notification channels
-    * @param sourceSystem The system sending the notification (your system)
-    * @param channel      The notification channel you'd like to use
-    * @param target       Specify who should receive the message
     * @param actions      Specify Call To Action buttons that will be put at the end of an email / hangout message
+    * @param target       Specify who should receive the message
+    * @param channel      The notification channel you'd like to use
+    * @param sourceSystem The system sending the notification (your system)
     * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
     * @param client       The SNS client that should be used to add your notification to the topic
-    * @return             Future of the resulting SNS Message ID
+    * @return             Future containing the resulting SNS Message ID
     */
-  def notify(subject: String, message: String, sourceSystem: String,
-             channel: RequestedChannel, target: List[Target], actions: List[Action],
-             topicArn: String,
-             client: AmazonSNSAsync = AWS.snsClient(AWS.credentialsProvider()))
+  def notify(subject: String, message: String, actions: List[Action], target: List[Target], channel: RequestedChannel,
+             sourceSystem: String, topicArn: String, client: AmazonSNSAsync = defaultClient)
             (implicit executionContext: ExecutionContext): Future[String] = {
     val request = new PublishRequest()
       .withTopicArn(topicArn)
       .withSubject(subject)
       .withMessage(messageJson(message, sourceSystem, channel, target, actions))
+    awsToScala(client.publishAsync)(request).map(_.getMessageId)
+  }
+
+  /**
+    * Sends a notification using Anghammarad.
+    *
+    * @param notification The notification to send
+    * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
+    * @return             Future containing the resulting SNS Message ID
+    */
+  def notify(notification: Notification, topicArn: String)
+            (implicit executionContext: ExecutionContext): Future[String] = {
+    val request = new PublishRequest()
+      .withTopicArn(topicArn)
+      .withSubject(notification.subject)
+      .withMessage(messageJson(notification.message, notification.sourceSystem, notification.channel, notification.target, notification.actions))
+    awsToScala(defaultClient.publishAsync)(request).map(_.getMessageId)
+  }
+
+  /**
+    * Sends a notification using Anghammarad.
+    *
+    * @param notification The notification to send
+    * @param topicArn     ARN of Anghammarad's SNS topic (you will need to obtain this and put it in your app's config)
+    * @param client       The SNS client that should be used to add your notification to the topic
+    * @return             Future containing the resulting SNS Message ID
+    */
+  def notify(notification: Notification, topicArn: String, client: AmazonSNSAsync)
+            (implicit executionContext: ExecutionContext): Future[String] = {
+    val request = new PublishRequest()
+      .withTopicArn(topicArn)
+      .withSubject(notification.subject)
+      .withMessage(messageJson(notification.message, notification.sourceSystem, notification.channel, notification.target, notification.actions))
     awsToScala(client.publishAsync)(request).map(_.getMessageId)
   }
 }

--- a/client/src/main/scala/com/gu/anghammarad/Json.scala
+++ b/client/src/main/scala/com/gu/anghammarad/Json.scala
@@ -11,6 +11,8 @@ object Json extends StrictLogging {
       case Email => "email"
       case HangoutsChat => "hangouts"
       case All => "all"
+      case Preferred(Email) => "prefer email"
+      case Preferred(HangoutsChat) => "prefer hangouts"
     }
     s"""{
        |  "message":${quoteJson(message)},
@@ -23,16 +25,13 @@ object Json extends StrictLogging {
 
   private[anghammarad] def targetJson(targets: List[Target]): String = {
     def targetJsonString(key: String, value: String) = s""""$key":${quoteJson(value)}"""
-    val kvpairs = targets.map (target => {
-      target match {
-        case Stack(stack) => targetJsonString("Stack", stack)
-        case Stage(stage) => targetJsonString("Stage", stage)
-        case App(app) => targetJsonString("App", app)
-        case AwsAccount(awsAccount) => targetJsonString("AwsAccount", awsAccount)
-        case _ => ""
-      }
-    }
-    ).mkString(",")
+    val kvpairs = targets.map {
+      case Stack(stack) => targetJsonString("Stack", stack)
+      case Stage(stage) => targetJsonString("Stage", stage)
+      case App(app) => targetJsonString("App", app)
+      case AwsAccount(awsAccount) => targetJsonString("AwsAccount", awsAccount)
+      case _ => ""
+    }.mkString(",")
     s"{$kvpairs}"
   }
 

--- a/common/src/main/scala/com/gu/anghammarad/models/models.scala
+++ b/common/src/main/scala/com/gu/anghammarad/models/models.scala
@@ -8,6 +8,7 @@ case class AwsAccount(awsAccount: String) extends Target
 
 sealed trait RequestedChannel
 case object All extends RequestedChannel
+case class Preferred(preferredChannel: Channel) extends RequestedChannel
 
 sealed trait Channel
 case object Email extends Channel with RequestedChannel

--- a/common/src/main/scala/com/gu/anghammarad/models/models.scala
+++ b/common/src/main/scala/com/gu/anghammarad/models/models.scala
@@ -40,12 +40,12 @@ case class HangoutMessage(
 ) extends Message
 
 case class Notification(
-  sourceSystem: String,
-  channel: RequestedChannel,
-  target: List[Target],
   subject: String,
   message: String,
-  actions: List[Action]
+  actions: List[Action],
+  target: List[Target],
+  channel: RequestedChannel,
+  sourceSystem: String
 )
 
 case class Action(


### PR DESCRIPTION
**NOTE:** This PR is based on this https://github.com/guardian/anghammarad/pull/33 to avoid conflicts. It's backed up while I'm in by myself :-(
Check [the single commit](https://github.com/guardian/anghammarad/commit/64359cf8f23e58277924e8763d678998bf769167) to see the diff, until that PR is merged.

Once this is merged, we should release another version of the client.
___________________

It's now possible to call notify with a data structure that represents a message, rather than having to pass each argument. This encourages better code style in our consumers, because they can write testable logic that generates a notification in a separate place to the actual IO for an invocation.

The `Notification` type was just used internally. Now that it is an exposed part of the interface, it made sense to tidy up the order of its arguments.

The existing `notify` function has had its arguments re-ordered to match the new method. It's now identical to call notify either way, less the Notification itself.

    notify( <message args> , topicArn [, client] )

    notify( Notification( <message args> ) , topicArn, [, client] )