### PR TITLE
Fix dev project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val root = project
     publishTo := sonatypePublishTo.value,
     releaseProcess += releaseStepCommandAndRemaining("sonatypeRelease")
   )
-  .aggregate(anghammarad, client, common)
+  .aggregate(anghammarad, client, common, dev)
 
 lazy val common = project
   .settings(

--- a/dev/src/main/scala/com/gu/anghammarad/ArgParser.scala
+++ b/dev/src/main/scala/com/gu/anghammarad/ArgParser.scala
@@ -29,17 +29,19 @@ object ArgParser {
               val message = Source.fromFile(file, "UTF-8").mkString
               j.copy(json = message)
             case _ => throw new RuntimeException("Arguments error")
-          },
+          }
+          .text("file containing JSON message"),
         opt[String]('j', "json")
           .action {
             case (message, j: Json) =>
               j.copy(json = message)
             case _ => throw new RuntimeException("Arguments error")
           }
+          .text("the raw JSON describing a message")
       )
     cmd("fields")
       .action { (_, _) =>
-        Specified("", None, Nil, "", "", Nil)
+        Specified("", "", Nil, Nil, None, "")
       }
       .text("specify fields directly")
       .children(
@@ -57,6 +59,13 @@ object ArgParser {
             case _ => throw new RuntimeException("Arguments error")
           }
           text "Specify email as the channel",
+        opt[Unit]("prefer-email")
+          .action {
+            case (_, fields: Specified) =>
+              fields.copy(channel = Some(Preferred(Email)))
+            case _ => throw new RuntimeException("Arguments error")
+          }
+          text "Specify email as the preferred channel",
         opt[Unit]("hangouts")
           .action {
             case (_, fields: Specified) =>
@@ -64,6 +73,13 @@ object ArgParser {
             case _ => throw new RuntimeException("Arguments error")
           }
           text "Specify hangouts chat as the channel",
+        opt[Unit]("prefer-hangouts")
+          .action {
+            case (_, fields: Specified) =>
+              fields.copy(channel = Some(Preferred(HangoutsChat)))
+            case _ => throw new RuntimeException("Arguments error")
+          }
+          text "Specify hangouts chat as the preferred channel",
         opt[Unit]("all")
           .action {
             case (_, fields: Specified) =>
@@ -144,10 +160,10 @@ case class Json(
   json: String
 ) extends Arguments
 case class Specified(
-  source: String,
-  channel: Option[RequestedChannel],
-  targets: List[Target],
   subject: String,
   message: String,
-  actions: List[Action]
+  actions: List[Action],
+  targets: List[Target],
+  channel: Option[RequestedChannel],
+  source: String
 ) extends Arguments

--- a/dev/src/main/scala/com/gu/anghammarad/Main.scala
+++ b/dev/src/main/scala/com/gu/anghammarad/Main.scala
@@ -24,9 +24,9 @@ object Main {
         logger.info(s"Config parsing succeeded: ${devMappings.isSuccess}")
 
         val sentMessages = for {
+          notification <- notificationFromArguments(arguments)
           config <- Config.loadConfig(stage)
           configuration <- Serialization.parseConfig(config)
-          notification <- notificationFromArguments(arguments)
           sent <- Anghammarad.run(notification, configuration)
         } yield sent
 
@@ -52,11 +52,12 @@ object Main {
           json <- parse(jsonStr).toTry
           notification <- Serialization.generateNotification(subject, json)
         } yield notification
-      case Specified(source, Some(channel), targets, subject, message, actions) =>
-        Success(Notification(source, channel, targets, subject, message, actions))
+      case Specified(subject, message, actions, targets, Some(channel), source) =>
+        Success(Notification(subject, message, actions, targets, channel, source))
       case s: Specified =>
         Fail("No channel provided")
       case InitialArgs =>
+        argParser.showUsageAsError()
         Fail("No arguments provided, cannot make a notification")
     }
   }


### PR DESCRIPTION
The dev project wasn't in the root project's `aggregate` definition. This means when I refactored and "fixed all the compile errors" I did not fix the dev project.

This corrects the `build.sbt` definition, and updates the dev project to match the re-ordered arguments. Also adds a missing `argParser.showUsageAsError()` invocation that I noticed was absent while testing.