### PR TITLE
Correct Anghammarad config s3 reference

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/Config.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Config.scala
@@ -37,8 +37,8 @@ object Config {
   def getStage(): String = Option(System.getenv("Stage")).getOrElse("DEV")
 
   def loadConfig(stage: String): Try[String] = {
-    val bucket = s"anghammarad-configuration/$stage"
-    val key = s"anghammarad-config.json"
+    val bucket = s"anghammarad-configuration"
+    val key = s"$stage/anghammarad-config.json"
 
     val request = new GetObjectRequest(bucket, key)
     fetchString(request)

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -42,6 +42,11 @@ class ContactsTest extends FreeSpec with Matchers with TryValues {
         resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("app1.email"), HangoutsRoom("app1.channel"))
       }
 
+      "matches stack from more specific target" in {
+        val targets = List(AwsAccount("foo"), Stack("stack1"), App("foo"), Stage("PROD"))
+        resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("stack1.email"), HangoutsRoom("stack1.channel"))
+      }
+
       "chooses correct stack match for specific target if stack is configured but app is not" in {
         val targets = List(AwsAccount("123456789"), Stack("stack1"), App("different-app"), Stage("PROD"))
         resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("stack1.email"), HangoutsRoom("stack1.channel"))


### PR DESCRIPTION
The bucket key was being put on the bucket name. This *may* be related to the config errors we've seen (but either way should be fixed).