### PR TITLE
Fix stage loading

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/Config.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Config.scala
@@ -5,9 +5,10 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{GetObjectRequest, S3ObjectInputStream}
+import com.gu.anghammarad.AnghammaradException.Fail
 
 import scala.io.Source
-import scala.util.Try
+import scala.util.{Success, Try}
 
 
 object Config {
@@ -34,7 +35,12 @@ object Config {
     } yield contentString
   }
 
-  def getStage(): String = Option(System.getenv("Stage")).getOrElse("DEV")
+  def getStage(): Try[String] = {
+    Option(System.getenv("Stage")) match {
+      case Some(stage) => Success(stage)
+      case None => Fail("Could nto find environment variable, 'Stage'")
+    }
+  }
 
   def loadConfig(stage: String): Try[String] = {
     val bucket = s"anghammarad-configuration"

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
@@ -9,9 +9,8 @@ import scala.util.{Failure, Success}
 
 class Lambda extends RequestHandler[SNSEvent, Unit] {
   override def handleRequest(input: SNSEvent, context: Context): Unit = {
-    val stage = Config.getStage()
-
     val sentMessages = for {
+      stage <- Config.getStage()
       config <- Config.loadConfig(stage)
       configuration <- Serialization.parseConfig(config)
       notification <- Serialization.parseNotification(input)

--- a/cloudformation/anghammarad.template.yaml
+++ b/cloudformation/anghammarad.template.yaml
@@ -59,6 +59,9 @@ Resources:
           Type: SNS
           Properties:
             Topic: !Ref NotificationTopic
+      Environment:
+        Variables:
+          Stage: !Ref Stage
       Tags:
         Stack: !FindInMap [ Constants, Stack, Value ]
         App: !FindInMap [ Constants, App, Value ]

--- a/dev/src/main/scala/com/gu/anghammarad/Main.scala
+++ b/dev/src/main/scala/com/gu/anghammarad/Main.scala
@@ -16,7 +16,7 @@ object Main {
 
     argParser.parse(args, InitialArgs) match {
       case Some(arguments) =>
-        val stage = Config.getStage()
+        val stage = "DEV"
         val devConfig = Config.loadConfig(stage)
         val devMappings = Serialization.parseAllMappings(devConfig.getOrElse(""))
 


### PR DESCRIPTION
Adds the Stage to the Lambda's environment so it can load the correct config.

We also now fail explicitly if the stage environment variable is missing. This stops confusing situations where we're accidentally using the DEV config.

The DEV app now uses DEV config explicitly. We can revisit this if needed.