### PR TITLE
Adds an Anghammarad notice to messages

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
@@ -38,19 +38,22 @@ object Messages {
         (notification.message + actionPrefix + htmlActions, notification.message + actionPrefix + plainTextActions)
       }
 
-    val md = mdParser.parse(markdown)
-    val html = mdRenderer.render(md)
+    val markdownWithNotice = markdown + anghammaradNotice(notification)
+    val plaintextWithNotice = plaintext + anghammaradNotice(notification)
+
+    val html = mdRenderer.render(mdParser.parse(markdownWithNotice))
 
     EmailMessage(
       notification.subject,
-      plaintext,
+      plaintextWithNotice,
       html
     )
   }
 
   def hangoutMessage(notification: Notification): HangoutMessage = {
-    val md = mdParser.parse(notification.message)
-    val html = mdRenderer.render(md)
+    val messageWithAnghammaradNotice = notification.message ++ anghammaradNotice(notification)
+
+    val html = mdRenderer.render(mdParser.parse(messageWithAnghammaradNotice))
       // hangouts chat supports a subset of tags that differs from the flexmark-generated HTML
       .replace("<strong>", "<b>").replace("</strong>", "</b>")
       .replace("<em>", "<i>").replace("</em>", "</i>")
@@ -107,6 +110,13 @@ object Messages {
        |    }
        |  }
        |}
+       |""".stripMargin
+  }
+
+  private def anghammaradNotice(notification: Notification): String = {
+    s"""
+       |
+       |This message was sent by ${notification.sourceSystem} via [Anghammarad](https://github.com/guardian/anghammarad).
        |""".stripMargin
   }
 }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
@@ -33,6 +33,11 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
           val notification = testNotification("subject", "message")
           emailMessage(notification).plainText should include("message")
         }
+
+        "includes the Anghammarad notice with source system" in {
+          val notification = testNotification("subject", "message")
+          emailMessage(notification).plainText should (include(notification.sourceSystem) and include("Anghammarad"))
+        }
       }
 
       "if actions are not present" - {
@@ -44,7 +49,12 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
 
         "uses the given message" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).plainText shouldEqual "message"
+          emailMessage(notification).plainText should startWith("message")
+        }
+
+        "includes the Anghammarad notice with source system" in {
+          val notification = testNotification("subject", "message")
+          emailMessage(notification).plainText should (include(notification.sourceSystem) and include("Anghammarad"))
         }
       }
     }
@@ -66,6 +76,11 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
           val notification = testNotification("subject", "message")
           emailMessage(notification).html should include("message")
         }
+
+        "includes the Anghammarad notice with source system" in {
+          val notification = testNotification("subject", "message")
+          emailMessage(notification).html should (include(notification.sourceSystem) and include("Anghammarad"))
+        }
       }
 
       "if actions are not present" - {
@@ -83,6 +98,11 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
         "converts markdown to HTML" in {
           val notification = testNotification("subject", "*em* **strong**")
           emailMessage(notification).html should (include("<em>em</em>") and include("<strong>strong</strong>"))
+        }
+
+        "includes the Anghammarad notice with source system" in {
+          val notification = testNotification("subject", "message")
+          emailMessage(notification).html should (include(notification.sourceSystem) and include("Anghammarad"))
         }
       }
     }
@@ -111,6 +131,11 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
         val message = hangoutMessage(notification)
         message.cardJson should include(s""""header": "subject"""")
       }
+
+      "includes the Anghammarad notice with source system" in {
+        val message = hangoutMessage(notification)
+        message.cardJson should (include(notification.sourceSystem) and include("Anghammarad"))
+      }
     }
 
     "if no actions are present" - {
@@ -129,6 +154,11 @@ class MessagesTest extends FreeSpec with Matchers with EitherValues {
         val message = hangoutMessage(notification)
         val json = parse(message.cardJson).right.value
         json.\\("buttons") shouldBe empty
+      }
+
+      "includes the Anghammarad notice with source system" in {
+        val message = hangoutMessage(notification)
+        message.cardJson should (include(notification.sourceSystem) and include("Anghammarad"))
       }
     }
   }


### PR DESCRIPTION
This gives people a heads up about:
* which system triggered the notification
* the fact that Anghammarad actually sent the message

I think we should get DevExp to iterate on this message, but good to at least give people some visibility of where the message came from.