### PR TITLE
Fix cross-build release settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ lazy val root = project
   .settings(
     name := "anghammarad-root",
     // publish settings
+    releaseCrossBuild := true,
     skip in publish := true,
     publishTo := sonatypePublishTo.value,
     releaseProcess += releaseStepCommandAndRemaining("sonatypeRelease")
@@ -51,7 +52,6 @@ lazy val common = project
   .settings(
     name := "anghammarad-common",
     // publish settings
-    releaseCrossBuild := true,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     publishTo := sonatypePublishTo.value
   )
@@ -67,7 +67,6 @@ lazy val client = project
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
     ),
     // publish settings
-    releaseCrossBuild := true,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     publishTo := sonatypePublishTo.value
   )


### PR DESCRIPTION
Previously, running `sbt release` only published for 2.12. I think `releaseCrossBuild`
should be set on the `root` project  as that's where the `release` command
actually runs. I haven't tested it though – v1.1.3 did go out to 2.11
and 2.12 but was triggered with `release cross`.