### PR TITLE
Convert Hangouts service to use sttp instead of lolhttp

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/HangoutsService.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/HangoutsService.scala
@@ -2,30 +2,31 @@ package com.gu.anghammarad.messages
 
 import com.gu.anghammarad.AnghammaradException.Fail
 import com.gu.anghammarad.models.HangoutMessage
-import lol.http.{Client, Post}
 
-import scala.concurrent.duration._
 import scala.util.{Success, Try}
-
+import sttp.client3._
 
 object HangoutsService {
-  // using a blocking call, but lolhttp still requires an execution context
-  import scala.concurrent.ExecutionContext.Implicits.global
 
-  val client = Client("chat.googleapis.com", 443, "https")
+  def postMessage(webhook: String, message: String): Response[Either[String, String]] = {
+    val backend = HttpURLConnectionBackend()
+    basicRequest
+      .body(message)
+      .post(uri"$webhook")
+      .send(backend)
+  }
+
+  def checkResponse(response: Response[Either[String,String]]): Try[Unit] = {
+    if (response.isSuccess)
+      Success(())
+    else
+      Fail(s"Unable to send message. Received response code of: ${response.statusText}.")
+  }
 
   def sendHangoutsMessage(webhook: String, message: HangoutMessage): Try[Unit] = {
-    val request = Post(webhook.stripPrefix("https://chat.googleapis.com"), message.cardJson)
-    val (status, response) = client.runSync(request, timeout = 5.seconds) { response =>
-      val status = response.status
-      for {
-        response <- response.readAs[String]
-      } yield (status, response)
-    }
-    if (status == 200) {
-      Success(())
-    } else {
-      Fail(s"Got $status from chat.googleapis.com, could not send message: $response")
-    }
+    for {
+      response <- Try {postMessage(webhook, message.cardJson)}
+      successOrFailure <- checkResponse(response)
+    } yield successOrFailure
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val anghammarad = project
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
-      "com.criteo.lolhttp" %% "lolhttp" % "0.9.2",
+      "com.softwaremill.sttp.client3" %% "core" % "3.3.16",
       "com.vladsch.flexmark" % "flexmark-all" % "0.32.18",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0",
       "ch.qos.logback" % "logback-classic" % "1.1.7",


### PR DESCRIPTION
## What does this change?
This is an issue found while working on [Publish Anghammarad client for Scala 2.13](https://github.com/guardian/anghammarad/pull/56). I have split this out into its own PR for simplicity as it is not relevant to the switch to Scala 2.13
The problem in question:
The http service used by the Anghammarad Lambda function to send messges from the SNS queue to google hangouts is continually failing with a certificate error. The cause appears to be that lolhttp libraries are out of date. The solution is to switch to using sttp for the hangouts service.

This change adopts the sttp service for posting to Google Hangouts, along with the necessary code changes. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

[x] Unit tests pass
[x] Running Main locally sends message to 'Team Alerts' hangout
[x] Forcing a failed error code into the response when running Main locally throws the correct error message.
[x] Deploying to CODE then using aws cli to send a message to the CODE SNS service causes the lambda to run and send a message to the 'Team Alerts' hangout 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See description above.

## How can we measure success?
Alerts will be sent to the relevant Google Hangout channel (currently in prod they are not being sent) - you may need to force an alert to be sent to the PROD SNS in order to trigger this.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
I expect alerts that we are currently missing to no longer be missed. As a result alerts will potentially increase, however this is only because problems that were always there are now being detected.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? --> This fixes an existing problem. Only risk is if the new http service breaks, but that just leaves us in the same position we are in now. Risks therefore are negligible.

