### PR TITLE
Update sbt-riffraff-artifact

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.12")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 


### PR DESCRIPTION
## What does this change?
Update sbt-riffraff-artifact to avoid warnings from AWS SDK on sbt startup.