### PR TITLE
Update sbt to version 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val root = project
     name := "anghammarad-root",
     // publish settings
     releaseCrossBuild := true,
-    skip in publish := true,
+    publish / skip := true,
     publishTo := sonatypePublishTo.value,
     releaseProcess += releaseStepCommandAndRemaining("sonatypeRelease")
   )
@@ -92,7 +92,7 @@ lazy val anghammarad = project
       "ch.qos.logback" % "logback-classic" % "1.2.6",
       "org.scalatest" %% "scalatest" % "3.2.9" % Test
     ),
-    skip in publish := true,
+    publish / skip := true,
     assemblyJarName := s"${name.value}.jar",
     riffRaffPackageType := assembly.value,
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.5.7

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0"
+ThisBuild / version := "1.2.0"


### PR DESCRIPTION
## What does this change?

This PR bumps `sbt` to version `1.5.7`, in order to pick up [an important fix](https://twitter.com/scala_sbt/status/1471015853495881730?s=20). 

I've also fixed a few warnings related to `sbt` syntax, based on: https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
