### PR TITLE
Remove superfluous dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ inThisBuild(Seq(
 
 val awsSdkVersion = "1.11.759"
 val circeVersion = "0.12.0-M3"
+val flexmarkVersion = "0.50.50"
 
 //Projects
 
@@ -87,7 +88,10 @@ lazy val anghammarad = project
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "com.softwaremill.sttp.client3" %% "core" % "3.3.16",
-      "com.vladsch.flexmark" % "flexmark-all" % "0.50.50",
+      "com.vladsch.flexmark" % "flexmark" % flexmarkVersion,
+      "com.vladsch.flexmark" % "flexmark-ext-gfm-strikethrough" % flexmarkVersion,
+      "com.vladsch.flexmark" % "flexmark-ext-tables" % flexmarkVersion,
+      "com.vladsch.flexmark" % "flexmark-util" % flexmarkVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
       "ch.qos.logback" % "logback-classic" % "1.2.6",
       "org.scalatest" %% "scalatest" % "3.2.9" % Test


### PR DESCRIPTION
## What does this change?

[`flexmark-all`](https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark-all) pulls in a large number of dependencies, many of which are not needed by this project. This is particularly problematic when the superfluous dependencies contain vulnerabilities. For example,  Snyk is flagging 8 vulnerabilities that are brought in via`flexmark-pdf-converter`.

This PR removes `flexmark-all` pulls in the specific `flexmark*` modules that we need, which helps to cut down on noise.

## How to test

Compilation & unit testing should be sufficient here.

## How can we measure success?

Fewer dependencies and fewer vulnerabilities in Snyk.

## Have we considered potential risks?

N/A
