### PR TITLE
Amend stage handling logic so that notifications for non-prod stages are not dropped

### DIFF
--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -407,16 +407,6 @@ class ContactsTest extends AnyFreeSpec with Matchers with TryValues {
         }
       }
 
-      "if a non-empty non-PROD stage is targeted, mappings without that stage will not be matched" - {
-        "fails to match if there is no matching non-PROD stage" in {
-          val targets = List(Stack("stack"), Stage("stage"))
-          val mappings = List(
-            Mapping(List(Stack("stack")), List(emailAddress))
-          )
-          resolveTargetContacts(targets, mappings).isFailure shouldBe true
-        }
-      }
-
       "if a stage is targeted, matches exact mappings for that stage" - {
         "fails to match if there is no matching non-PROD stage" in {
           val targets = List(Stack("stack"), Stage("stage"))

--- a/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
@@ -8,17 +8,6 @@ import org.scalatest.matchers.should.Matchers
 class TargetsTest extends AnyFreeSpec with Matchers {
   import com.gu.anghammarad.Targets._
 
-  "normaliseStages" - {
-    "adds PROD stage to a list of targets that does not include stage" in {
-      normaliseStages(List(AwsAccount("123456789"), App("app"))) should contain(Stage("PROD"))
-    }
-
-    "does not change a list of targets that already includes a stage" in {
-      val targets = List(Stage("stage"), AwsAccount("123456789"), App("app"))
-      normaliseStages(targets) shouldEqual targets
-    }
-  }
-
   "includesAwsAccount" - {
     "returns false if AwsAccount is enquired about and not present" in {
       includesAwsAccount(List(App("app"))) shouldBe false
@@ -186,5 +175,24 @@ class TargetsTest extends AnyFreeSpec with Matchers {
       )
       sortMappingsByTargets(targets, mappings).head.contacts shouldEqual expected
     }
+
+    "PROD stage in mappings determines priority if two otherwise equivalent matches are found" in {
+      val targets = List(App("app"))
+      val mappings = List(
+        Mapping(List(App("app"), Stage("PROD")), expected),
+        Mapping(List(App("app"), Stage("CODE")), unexpected),
+      )
+      sortMappingsByTargets(targets, mappings).head.contacts shouldEqual expected
+    }
+
+    "Lack of stage in mappings gets priority over a specific CODE mapping if two otherwise equivalent matches are found" in {
+      val targets = List(App("app"))
+      val mappings = List(
+        Mapping(List(App("app")), expected),
+        Mapping(List(App("app"), Stage("CODE")), unexpected),
+      )
+      sortMappingsByTargets(targets, mappings).head.contacts shouldEqual expected
+    }
+
   }
 }


### PR DESCRIPTION
## What does this change?

This PR modifies Anghammarad's logic to make it less opinionated about stages.

Prior to this PR, [Anghammarad would drop notifications where the stage is not `PROD` unless we have explicitly included config for non-PROD stages](https://github.com/guardian/anghammarad/blob/cce3fc999b3a86893039c604501d4dc703aad095/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala#L410-L418). 

In practice, there are very few config mappings for `CODE`, so this means that failed scheduled deployments to `CODE` and security notifications about `CODE` environments will not be delivered to most teams. This is undesirable because notifications like that can still lead to vulnerabilities or SLO violations that teams ought to address.

This change allows the source system to decide whether to send an alert or not, depending on the scenario (e.g. if the source system thinks it is not appropriate to send alerts related to `CODE` environment, it becomes responsible for the filtering).

## How to test

The unit tests in this project are comprehensive so I think CI passing should be sufficient here.

## How can we measure success?

We will send more actionable notifications to teams and the error % for this Lambda should reduce significantly.

## Have we considered potential risks?

Yes, there is a small risk that some clients will have been relying on the old behaviour and that we will introduce some undesirable alerts by modifying it. I have manually checked (using GitHub search) and I do not think there are any scenarios where the old behaviour is relied upon.