### PR TITLE
Deploy infrastructure with Riff-Raff and add monitoring

### DIFF
--- a/anghammarad/riff-raff.yaml
+++ b/anghammarad/riff-raff.yaml
@@ -3,6 +3,11 @@ stacks:
 regions:
 - eu-west-1
 deployments:
+  cfn:
+    type: cloud-formation
+    app: anghammarad
+    parameters:
+      templatePath: cfn.yaml
   anghammarad:
     type: aws-lambda
     parameters:
@@ -11,3 +16,5 @@ deployments:
       prefixStack: false
       functionNames:
       - anghammarad-
+    dependencies:
+      - cfn

--- a/cloudformation/anghammarad.template.yaml
+++ b/cloudformation/anghammarad.template.yaml
@@ -22,6 +22,12 @@ Parameters:
   AllowedAWSAccountIDs:
     Description: List of AWS account IDs to grant SNS Publish permission to
     Type: CommaDelimitedList
+  SendAlarmNotifications:
+    Type: String
+    Default: TRUE
+    AllowedValues:
+    - TRUE
+    - FALSE
 
 Mappings:
   Constants:
@@ -31,6 +37,13 @@ Mappings:
       Value: anghammarad
 
 Resources:
+
+  DeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub anghammarad-${Stage}-dead-letters
+      KmsMasterKeyId: alias/aws/sqs
+
   ProcessorFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -66,6 +79,9 @@ Resources:
         Stack: !FindInMap [ Constants, Stack, Value ]
         App: !FindInMap [ Constants, App, Value ]
         Stage: !Ref Stage
+      DeadLetterQueue:
+        TargetArn: !GetAtt DeadLetterQueue.Arn
+        Type: SQS
 
   NotificationTopic:
     Type: AWS::SNS::Topic
@@ -85,6 +101,28 @@ Resources:
           Resource: "*"
       Topics:
       - !Ref NotificationTopic
+
+  DlqDepthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub | 
+        Triggers if Anghammarad failed to process some messages in ${Stage}.
+        
+        For suggested actions, see: https://docs.google.com/document/d/1cDd9mVAKFAYibuBPiCw4HkSCl16dG5zSu0qdSXDPuSE/edit#
+
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt DeadLetterQueue.QueueName
+      Period: 60
+      Statistic: Sum
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions: [ !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devx-sec-ops-reliability-alerts" ]
+      ActionsEnabled: !Ref SendAlarmNotifications
+      TreatMissingData: notBreaching
 
 Outputs:
   TopicName:


### PR DESCRIPTION
## What does this change?

This PR:

1. Allows us to deploy CloudFormation changes using Riff-Raff (presumably the process has been manual up until this point): https://github.com/guardian/anghammarad/pull/73/commits/296bf3353122b2b6343734fc68f426ba47706d21.
2. Adds a dead letter queue and an alarm, so that we can be notified when Anghammarad (repeatedly) fails to send a notification to teams: https://github.com/guardian/anghammarad/pull/73/commits/4617b5935c4cf97a6e0c1745e2fedde7feae33a0.

## How to test

I've deployed this to `CODE` and confirmed that:

1. Riff-Raff updates the infrastructure correctly.
2. An alarm is triggered under the right circumstances.

## How can we measure success?

We will now be informed when Anghammarad cannot deliver notifications.

## Have we considered potential risks?

Adding alerts always introduces a risk of increasing the number of interruptions. This can be particularly frustrating if the alert does not require an action. In order to mitigate this risk I have:

1. Used a dead letters queue (rather than just looking at lambda errors). Messages will only be sent to this queue after Anghammarad has [tried to process them 3 times (over several minutes)](https://stackoverflow.com/a/60425011), so hopefully transient problems should be resolved automatically without interrupting developers. In the future, we could increase the number of retries, if desired.

2. Provided a link to a runbook[^1] with suggested debugging steps & actions from within the alert notification.

[^1]: The runbook needs a few final changes after this PR is merged (e.g. a link to the `PROD` dead letters queue, which doesn't exist yet) 