### PR TITLE
Add the capability to test client / topic publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,26 @@ and it will require the sns:Publish action. Here is an [example](https://github.
 
 A test [google group](https://groups.google.com/a/guardian.co.uk/g/anghammarad.test.alerts) has been created, so that you can test your notification. The stack for this is called "testing-alerts". You can also find this in the Anghammarad config in S3.
 
-You can try out the `CODE` deployment before promoting to `PROD`, by obtaining "Deploy Tools" developer credentials from Janus and running:
+You can try out your local changes by obtaining "Deploy Tools" developer credentials from Janus and running:
 
 ```shell
 sbt "project dev" "run fields --config-stage CODE --targets Stack=testing-alerts --subject my_test_message --message testing --source test_user --email"
 ```
 
-This will send a message to the test group indicated above.
+This will use `AnghammaradService.run` to send a message to the test group indicated above.
+
+If you need to invoke the Lambda function (for example to test IAM permissions), in `CODE` or `PROD` you can also publish a message to one of Anghammarad's SNS topics by running:
+
+```shell
+# Set the ENV ("CODE" or "PROD")
+ENV="CODE"
+# Get the SNS topic for a particular environment from SSM: 
+TOPIC_ARN=$(aws ssm get-parameter --name /$ENV/deploy/amigo/anghammarad.sns.topicArn --region eu-west-1 --profile deployTools | jq -r ".Parameter.Value")
+# Send a notification to the topic using the --use-topic $TOPIC_ARN flag
+sbt "project dev" "run fields --config-stage CODE --targets Stack=testing-alerts --subject my_test_message --message testing --source test_user --email --use-topic $TOPIC_ARN"
+```
+
+This will use `Anhammarad.notify` from the client project, allowing you to test it is working as expected as well as being able to test `CODE` & `PROD` are behaving.
 
 ### Node Client
 

--- a/anghammarad/src/main/scala/com/gu/anghammarad/AnghammaradService.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/AnghammaradService.scala
@@ -6,7 +6,7 @@ import com.gu.anghammarad.messages.{Messages, SendMessages}
 import scala.util.Try
 
 
-object Anghammarad {
+object AnghammaradService {
   def run(notification: Notification, config: Configuration): Try[List[(Message, Contact)]] = {
     // resolve targets
     for {

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
@@ -17,7 +17,7 @@ class Lambda extends RequestHandler[SNSEvent, Unit] {
       config <- Config.loadConfig(stage)
       configuration <- Serialization.parseConfig(config)
       notification <- parseNotification
-      sent <- Anghammarad.run(notification, configuration)
+      sent <- AnghammaradService.run(notification, configuration)
     } yield sent
 
     // send notification if result is a failure

--- a/build.sbt
+++ b/build.sbt
@@ -120,4 +120,4 @@ lazy val dev = project
     ),
     publish / skip := true
   )
-  .dependsOn(common, anghammarad)
+  .dependsOn(common, anghammarad, client)

--- a/dev/src/main/scala/com/gu/anghammarad/Main.scala
+++ b/dev/src/main/scala/com/gu/anghammarad/Main.scala
@@ -7,46 +7,79 @@ import com.gu.anghammarad.serialization.Serialization
 import io.circe.parser._
 import org.slf4j.{Logger, LoggerFactory}
 
-import cats.syntax.either._
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 object Main {
+
+  def sendNotificationUsingService(notification: Notification, stage: String): Unit = {
+    val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+    val sentMessages = for {
+      config <- Config.loadConfig(stage)
+      configuration <- Serialization.parseConfig(config)
+      sent <- AnghammaradService.run(notification, configuration)
+    } yield sent
+
+    sentMessages match {
+      case Failure(err) =>
+        logger.error("Failed to send notification", err)
+      case Success(sent) =>
+        sent.map {
+          case (_, EmailAddress(email)) => s"Email: $email"
+          case (_, HangoutsRoom(webhook)) => s"Hangouts webhook: $webhook"
+        }
+        logger.info(s"sent notification ${sent.mkString(",")}")
+    }
+  }
+
+  def sendNotificationUsingClient(notification: Notification, topicArn: String): Unit = {
+    val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+    val sendNotice = Anghammarad.notify(notification, topicArn)
+
+    sendNotice onComplete {
+      case Success(messageId) =>
+        logger.info(s"sent notification to ${topicArn}, got id: ${messageId}")
+      case Failure(err) =>
+        logger.error("Failed to send notification", err)
+    }
+
+    Await.ready(
+      sendNotice,
+      Duration("5 seconds")
+    )
+  }
+
   def main(args: Array[String]): Unit = {
     val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
     argParser.parse(args, InitialArgs) match {
       case Some(arguments) =>
-        val sentMessages = for {
+        for {
           notification <- notificationFromArguments(arguments)
           stage <- stageFromArguments(arguments)
-          config <- Config.loadConfig(stage)
-          configuration <- Serialization.parseConfig(config)
-          sent <- Anghammarad.run(notification, configuration)
-        } yield sent
-
-        sentMessages match {
-          case Failure(err) =>
-            logger.error("Failed to send notification", err)
-          case Success(sent) =>
-            sent.map {
-              case (_, EmailAddress(email)) => s"Email: $email"
-              case (_, HangoutsRoom(webhook)) => s"Hangouts webhook: $webhook"
-            }
-            logger.info(s"sent notification ${sent.mkString(",")}")
+          useClient <- useClientFromArguments(arguments)
+        } yield useClient match {
+          case Some(topicArn) => sendNotificationUsingClient(notification, topicArn)
+          case None => sendNotificationUsingService(notification, stage)
         }
+
       case None =>
-        // arguments were not valid, help will have been printed
+      // arguments were not valid, help will have been printed
     }
   }
 
   def notificationFromArguments(args: Arguments): Try[Notification] = {
     args match {
-      case Json(subject, jsonStr, _) =>
+      case JsonArgs(subject, jsonStr, _) =>
         for {
           json <- parse(jsonStr).toTry
           notification <- Serialization.generateNotification(subject, json)
         } yield notification
-      case Specified(subject, message, actions, targets, Some(channel), source, _) =>
+      case Specified(subject, message, actions, targets, Some(channel), source, _, _) =>
         Success(Notification(subject, message, actions, targets, channel, source))
       case s: Specified =>
         Fail("No channel provided")
@@ -58,10 +91,22 @@ object Main {
 
   def stageFromArguments(args: Arguments): Try[String] = {
     args match {
-      case Json(_, _, configStage) =>
+      case JsonArgs(_, _, configStage) =>
         Success(configStage)
-      case Specified(_, _, _, _, _, _, configStage) =>
+      case Specified(_, _, _, _, _, _, configStage, _) =>
         Success(configStage)
+      case InitialArgs =>
+        argParser.showUsageOnError
+        Fail("No arguments provided, cannot obtain a configuration stage")
+    }
+  }
+
+  def useClientFromArguments(args: Arguments): Try[Option[String]] = {
+    args match {
+      case JsonArgs(_, _, _) =>
+        Success(None)
+      case Specified(_, _, _, _, _, _, _, useClient) =>
+        Success(useClient)
       case InitialArgs =>
         argParser.showUsageOnError
         Fail("No arguments provided, cannot obtain a configuration stage")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.0"
+ThisBuild / version := "1.7.3"


### PR DESCRIPTION
## What does this change?

This change adds the ability to use the `dev` project to publish notifications to SNS, exercising the local client code and also providing the ability to easily test the lambda in `CODE` and `PROD`.

## How to test

Review the [documentation update](https://github.com/guardian/anghammarad/blob/rk/dev-use-client/README.md#testing-your-notification) for instructions on testing this change.