### PR TITLE
Add GithubTeamSlug as an Anghammarad target

### DIFF
--- a/anghammarad-client-node/src/interfaces.ts
+++ b/anghammarad-client-node/src/interfaces.ts
@@ -10,6 +10,7 @@ export interface Target {
   Stage?: string;
   App?: string;
   AwsAccount?: string;
+  GithubTeamSlug?: string;
 }
 
 export enum RequestedChannel {

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Contacts.scala
@@ -77,6 +77,7 @@ object Contacts {
           if (includesApp(mappingTargets)) appMatches(targets, mappingTargets)
           else if (includesStack(mappingTargets)) stackMatches(targets, mappingTargets)
           else if (includesAwsAccount(mappingTargets)) awsAccountMatches(targets, mappingTargets)
+          else if (includesGithubTeamSlug(mappingTargets)) githubTeamSlugMatches(targets, mappingTargets)
           else true
         }
         sortMappingsByTargets(targets, validMatches)

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Targets.scala
@@ -12,6 +12,9 @@ object Targets {
     { case a @ App(_) => a }
   private val collectStage: PartialFunction[Target, Stage] =
     { case s @ Stage(_) => s }
+  private val collectGithubTeamSlug: PartialFunction[Target, GithubTeamSlug] = {
+    case s@GithubTeamSlug(_) => s
+  }
 
   def includesAwsAccount(targets: List[Target]): Boolean = {
     targets.collect(collectAwsAccount).nonEmpty
@@ -28,6 +31,11 @@ object Targets {
   def includesStage(targets: List[Target]): Boolean = {
     targets.collect(collectStage).nonEmpty
   }
+
+  def includesGithubTeamSlug(targets: List[Target]): Boolean = {
+    targets.collect(collectGithubTeamSlug).nonEmpty
+  }
+
 
   def stageMatches(targets1: List[Target], targets2: List[Target]): Boolean = {
     val stages1 = targets1.collect(collectStage).toSet
@@ -52,6 +60,13 @@ object Targets {
     val apps2 = targets2.collect(collectApp).toSet
     (apps1 intersect apps2).nonEmpty
   }
+
+  def githubTeamSlugMatches(targets1: List[Target], targets2: List[Target]): Boolean = {
+    val githubTeamSlug1 = targets1.collect(collectGithubTeamSlug).toSet
+    val githubTeamSlug2 = targets2.collect(collectGithubTeamSlug).toSet
+    (githubTeamSlug1 intersect githubTeamSlug2).nonEmpty
+  }
+
 
   def shouldDefaultBasedOnStage(targets1: List[Target], targets2: List[Target]): Boolean = {
     val prodOrStagelessMapping = targets1.collect(collectStage).toSet.contains(Stage("PROD")) || !includesStage(targets1)

--- a/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
@@ -119,6 +119,7 @@ object Serialization {
       case "Stage" => Success(Stage(value))
       case "App" => Success(App(value))
       case "AwsAccount" => Success(AwsAccount(value))
+      case "GithubTeamSlug" => Success(GithubTeamSlug(value))
       case _ => Fail(s"Unable to match keys to known targets")
     }
   }

--- a/anghammarad/src/test/resources/contacts-integration-fixture.json
+++ b/anghammarad/src/test/resources/contacts-integration-fixture.json
@@ -89,6 +89,24 @@
       "contacts": {
         "email": "app3.CODE.email"
       }
+    },
+    {
+      "target": {
+        "GithubTeamSlug": "slug4"
+      },
+      "contacts": {
+        "email": "slug4.email"
+      }
+    },
+    {
+      "target": {
+        "Stack": "stack4",
+        "Stage": "PROD4",
+        "App": "app4"
+      },
+      "contacts": {
+        "email": "stack4.email"
+      }
     }
   ]
 }

--- a/anghammarad/src/test/resources/contacts-integration-fixture.json
+++ b/anghammarad/src/test/resources/contacts-integration-fixture.json
@@ -72,6 +72,23 @@
       "contacts": {
         "email": "app2.CODE.email"
       }
+    },
+    {
+      "target": {
+        "GithubTeamSlug": "slug1"
+      },
+      "contacts": {
+        "email": "app2.CODE.email"
+      }
+    },
+    {
+      "target": {
+        "GithubTeamSlug": "slug1",
+        "Stack": "stack2"
+      },
+      "contacts": {
+        "email": "app3.CODE.email"
+      }
     }
   ]
 }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -68,6 +68,11 @@ class ContactsTest extends AnyFreeSpec with Matchers with TryValues {
         resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("app2.CODE.email"))
       }
 
+      "chooses Stack,Stage, App over GithubTeamSlug" in {
+        val targets = List(GithubTeamSlug("slug4"), Stack("stack4"), App("app4"), Stage("PROD4"))
+        resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("stack4.email"))
+      }
+
 //      We don't support matching multiple choices on GithubTeamSlug - yet...
 //      "chooses most specific GithubTeamSlug match multiple choices (matches mapping with stack and githubTeamSlug, not the one with just githubTeamSlug)" in {
 //        val targets = List(AwsAccount("slug1"), Stack("stack2"))

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -57,6 +57,22 @@ class ContactsTest extends AnyFreeSpec with Matchers with TryValues {
         val targets = List(AwsAccount("123456789"), Stack("different-stack"), App("different-app"), Stage("PROD"))
         resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("123456789.email"))
       }
+
+      "chooses correct GithubTeamSlug match for specific target if GithubTeamSlug is configured" in {
+        val targets = List(GithubTeamSlug("slug1"))
+        resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("app2.CODE.email"))
+      }
+
+      "chooses correct GithubTeamSlug match for specific target if GithubTeamSlug is configured but stack and app are not" in {
+        val targets = List(GithubTeamSlug("slug1"), Stack("different-stack"), App("different-app"), Stage("PROD"))
+        resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("app2.CODE.email"))
+      }
+
+//      We don't support matching multiple choices on GithubTeamSlug - yet...
+//      "chooses most specific GithubTeamSlug match multiple choices (matches mapping with stack and githubTeamSlug, not the one with just githubTeamSlug)" in {
+//        val targets = List(AwsAccount("slug1"), Stack("stack2"))
+//        resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("stack2.app1.email"))
+//      }
     }
 
     "cannot resolve from empty mappings" in {

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -68,16 +68,18 @@ class ContactsTest extends AnyFreeSpec with Matchers with TryValues {
         resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("app2.CODE.email"))
       }
 
-      "chooses Stack,Stage, App over GithubTeamSlug" in {
-        val targets = List(GithubTeamSlug("slug4"), Stack("stack4"), App("app4"), Stage("PROD4"))
-        resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("stack4.email"))
+      "does not choose GithubTeamSlug when another exact mapping is provided" in {
+        val stackStageAppTargets = List(GithubTeamSlug("slug4"), Stack("stack4"), App("app4"), Stage("PROD4"))
+        val accountIdTarget = List(GithubTeamSlug("slug4"), AwsAccount("111111111"))
+        val exactStackTarget = List(GithubTeamSlug("slug4"), Stack("stack1"))
+        resolveTargetContacts(stackStageAppTargets, mappings).success shouldEqual List(EmailAddress("stack4.email"))
+        resolveTargetContacts(accountIdTarget, mappings).success shouldEqual List(EmailAddress("111111111.email"))
+        resolveTargetContacts(exactStackTarget, mappings).success shouldEqual List(EmailAddress("stack1.email"), HangoutsRoom("stack1.channel"))
       }
-
-//      We don't support matching multiple choices on GithubTeamSlug - yet...
-//      "chooses most specific GithubTeamSlug match multiple choices (matches mapping with stack and githubTeamSlug, not the one with just githubTeamSlug)" in {
-//        val targets = List(AwsAccount("slug1"), Stack("stack2"))
-//        resolveTargetContacts(targets, mappings).success shouldEqual List(EmailAddress("stack2.app1.email"))
-//      }
+      "chooses GithubTeamSlug when an alternative, underspecified match is provided" in {
+        val stackTargets = List(GithubTeamSlug("slug4"), Stack("stack4"))
+        resolveTargetContacts(stackTargets, mappings).success shouldEqual List(EmailAddress("slug4.email"))
+      }
     }
 
     "cannot resolve from empty mappings" in {

--- a/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/TargetsTest.scala
@@ -136,6 +136,28 @@ class TargetsTest extends AnyFreeSpec with Matchers {
     }
   }
 
+  "githubTeamSlugMatches" - {
+    "returns true if the Slugs match" in {
+      githubTeamSlugMatches(List(GithubTeamSlug("slugs")), List(GithubTeamSlug("slugs"))) shouldBe true
+    }
+
+    "returns true if the Slugs match among other targets" in {
+      githubTeamSlugMatches(List(GithubTeamSlug("slugs"), Stack("stack")), List(AwsAccount("123456789"), GithubTeamSlug("slugs"))) shouldBe true
+    }
+
+    "returns false if the Slugs do not match" in {
+      githubTeamSlugMatches(List(GithubTeamSlug("slugs1")), List(GithubTeamSlug("slugs2"))) shouldBe false
+    }
+
+    "returns false if the Slugs do not match among other targets" in {
+      githubTeamSlugMatches(List(Stack("stack"), GithubTeamSlug("slugs1")), List(GithubTeamSlug("slugs2"), AwsAccount("123456789"))) shouldBe false
+    }
+
+    "returns true if multiple Slugs are present as long as there is an overlap" in {
+      githubTeamSlugMatches(List(GithubTeamSlug("slugs1"), GithubTeamSlug("slugs2")), List(GithubTeamSlug("slugs1"))) shouldBe true
+    }
+  }
+
   "sortMappingsByTargets" - {
     val expected = List(EmailAddress("expected"))
     val unexpected = List(EmailAddress("unexpected"))

--- a/common/src/main/scala/com/gu/anghammarad/models/models.scala
+++ b/common/src/main/scala/com/gu/anghammarad/models/models.scala
@@ -5,6 +5,7 @@ case class Stack(stack: String) extends Target
 case class Stage(stage: String) extends Target
 case class App(app: String) extends Target
 case class AwsAccount(awsAccount: String) extends Target
+case class GithubTeamSlug(slug: String) extends Target
 
 sealed trait RequestedChannel
 case object All extends RequestedChannel


### PR DESCRIPTION
## What does this change?
Adds GithubTeamSlug as an Anghammarad target, allowing us to route a message to a P&E team based on a GitHub team.

The initial use-case for this is RepoCop. RepoCop will:
- Identify a GitHub repository that is failing on some rules
- Send a message to the repo's owner
- Take action based on the owner's response

RepoCop's message to Anghammarad will contain exactly one `GithubTeamSlug` target. RepoCop does not know (or care) about the existing targets (Stack, Stage, App, Account). That is, we don't anticipate an Anghammarad client targeting both `GithubTeamSlug` _and_ another target. We have however added a test for this unlikely scenario.