### PR TITLE
feat(hangouts): Threading!

### DIFF
--- a/anghammarad-client-node/src/interfaces.ts
+++ b/anghammarad-client-node/src/interfaces.ts
@@ -30,4 +30,5 @@ export interface NotifyParams {
   sourceSystem: string;
   topicArn: string;
   client?: SNS;
+  threadKey?: string;
 }

--- a/anghammarad-client-node/src/main.ts
+++ b/anghammarad-client-node/src/main.ts
@@ -10,12 +10,22 @@ export class Anghammarad {
   }
 
   messageJson(params: NotifyParams): string {
+    const {
+      message,
+      sourceSystem,
+      channel,
+      target,
+      actions,
+      threadKey
+    } = params
+
     return JSON.stringify({
-      message: params.message,
-      sender: params.sourceSystem,
-      channel: params.channel,
-      target: params.target,
-      actions: params.actions,
+      message,
+      sender: sourceSystem,
+      channel,
+      target,
+      actions,
+      ...(threadKey && { threadKey }), // only add "threadKey" when it is defined
     });
   }
 

--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/HangoutsService.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/HangoutsService.scala
@@ -8,11 +8,16 @@ import sttp.client3._
 
 object HangoutsService {
 
-  def postMessage(webhook: String, message: String): Response[Either[String, String]] = {
+  def postMessage(webhook: String, message: HangoutMessage): Response[Either[String, String]] = {
+    val endpoint = message.threadKey match {
+      case Some(threadKey) => uri"$webhook&threadKey=$threadKey"
+      case _ => uri"$webhook"
+    }
+
     val backend = HttpURLConnectionBackend()
     basicRequest
-      .body(message)
-      .post(uri"$webhook")
+      .body(message.cardJson)
+      .post(endpoint)
       .send(backend)
   }
 
@@ -25,7 +30,7 @@ object HangoutsService {
 
   def sendHangoutsMessage(webhook: String, message: HangoutMessage): Try[Unit] = {
     for {
-      response <- Try {postMessage(webhook, message.cardJson)}
+      response <- Try {postMessage(webhook, message)}
       successOrFailure <- checkResponse(response)
     } yield successOrFailure
   }

--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
@@ -86,7 +86,7 @@ object Messages {
          |  ]
          |}
          |""".stripMargin
-    HangoutMessage(json)
+    HangoutMessage(json, notification.threadKey)
   }
 
   private def buttonJson(actions: List[Action]): String = {

--- a/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/serialization/Serialization.scala
@@ -62,10 +62,11 @@ object Serialization {
       rawChannel <- hCursor.downField("channel").as[String]
       rawActions <- hCursor.downField("actions").as[List[Json]]
       message <- hCursor.downField("message").as[String]
+      threadKey <- hCursor.downField("threadKey").as[Option[String]]
       channel <- parseRequestedChannel(rawChannel).toEither
       targets <- parseAllTargets(rawTargets).toEither
       actions <- rawActions.traverseT(parseAction).toEither
-    } yield Notification(subject, message, actions, targets, channel, sourceSystem)
+    } yield Notification(subject, message, actions, targets, channel, sourceSystem, threadKey)
 
     parsingResult.toTry
   }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/ContactsTest.scala
@@ -13,7 +13,7 @@ import scala.io.Source
 class ContactsTest extends AnyFreeSpec with Matchers with TryValues {
   val email = EmailMessage("subject", "text", "html")
   val emailAddress = EmailAddress("test@example.com")
-  val hangoutMessage = HangoutMessage("json")
+  val hangoutMessage = HangoutMessage("json", None)
   val hangoutsRoom = HangoutsRoom("webhook")
 
   "resolveTargetContacts" - {

--- a/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
@@ -166,7 +166,7 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
   }
 
   def testNotification(subject: String, message: String, actions: Action*): Notification = {
-    Notification(subject, message, actions.toList, Nil, All, "test")
+    Notification(subject, message, actions.toList, Nil, All, "test", None)
   }
 
   /**
@@ -185,7 +185,8 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
       List(Action("CTA", "https://example.com/"), Action("Another CTA", "https://example.com/")),
       Nil,
       HangoutsChat,
-      "Testing"
+      "Testing",
+      None
     )
     val message = Messages.hangoutMessage(notification)
     // println(message.cardJson)

--- a/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/serialization/SerializationTest.scala
@@ -27,7 +27,8 @@ class SerializationTest extends AnyFreeSpec with Matchers with EitherValues with
       List(Action("keep that name moving in the Overhead", "http://www.gnuterrypratchett.com/")),
       List(Stack("postal-service"), App("clacks-overhead")),
       Email,
-      "Terry Pratchett"
+      "Terry Pratchett",
+      None
     )
 
     "parseNotification" - {

--- a/common/src/main/scala/com/gu/anghammarad/models/models.scala
+++ b/common/src/main/scala/com/gu/anghammarad/models/models.scala
@@ -48,7 +48,7 @@ case class Notification(
   target: List[Target],
   channel: RequestedChannel,
   sourceSystem: String,
-  threadKey: Option[String] // only used for Hangouts messages
+  threadKey: Option[String] = None // only used for Hangouts messages
 )
 
 case class Action(

--- a/common/src/main/scala/com/gu/anghammarad/models/models.scala
+++ b/common/src/main/scala/com/gu/anghammarad/models/models.scala
@@ -37,7 +37,8 @@ case class EmailMessage(
   html: String
 ) extends Message
 case class HangoutMessage(
-  cardJson: String
+  cardJson: String,
+  threadKey: Option[String]
 ) extends Message
 
 case class Notification(
@@ -46,7 +47,8 @@ case class Notification(
   actions: List[Action],
   target: List[Target],
   channel: RequestedChannel,
-  sourceSystem: String
+  sourceSystem: String,
+  threadKey: Option[String] // only used for Hangouts messages
 )
 
 case class Action(

--- a/dev/src/main/scala/com/gu/anghammarad/ArgParser.scala
+++ b/dev/src/main/scala/com/gu/anghammarad/ArgParser.scala
@@ -49,7 +49,7 @@ object ArgParser {
       )
     cmd("fields")
       .action { (_, _) =>
-        Specified("", "", Nil, Nil, None, "", Arguments.defaultStage, None)
+        Specified("", "", Nil, Nil, None, "", Arguments.defaultStage, None, None)
       }
       .text("specify fields directly")
       .children(
@@ -171,6 +171,13 @@ object ArgParser {
             case _ => throw new RuntimeException("Arguments error")
           }
           text "Send message using client (will publish to SNS topic)",
+        opt[String]("thread-key")
+          .optional()
+          .action {
+            case (threadKey, fields: Specified) =>
+              fields.copy(threadKey = Some(threadKey))
+            case _ => throw new RuntimeException("Arguments error")
+          }
       )
   }
 
@@ -192,7 +199,8 @@ case class Specified(
   channel: Option[RequestedChannel],
   source: String,
   configStage: String,
-  useTopic: Option[String]
+  useTopic: Option[String],
+  threadKey: Option[String]
 ) extends Arguments
 object Arguments {
   val defaultStage = "DEV"

--- a/dev/src/main/scala/com/gu/anghammarad/Main.scala
+++ b/dev/src/main/scala/com/gu/anghammarad/Main.scala
@@ -79,8 +79,8 @@ object Main {
           json <- parse(jsonStr).toTry
           notification <- Serialization.generateNotification(subject, json)
         } yield notification
-      case Specified(subject, message, actions, targets, Some(channel), source, _, _) =>
-        Success(Notification(subject, message, actions, targets, channel, source))
+      case Specified(subject, message, actions, targets, Some(channel), source, _, _, threadKey) =>
+        Success(Notification(subject, message, actions, targets, channel, source, threadKey))
       case s: Specified =>
         Fail("No channel provided")
       case InitialArgs =>
@@ -93,7 +93,7 @@ object Main {
     args match {
       case JsonArgs(_, _, configStage) =>
         Success(configStage)
-      case Specified(_, _, _, _, _, _, configStage, _) =>
+      case Specified(_, _, _, _, _, _, configStage, _, _) =>
         Success(configStage)
       case InitialArgs =>
         argParser.showUsageOnError
@@ -105,7 +105,7 @@ object Main {
     args match {
       case JsonArgs(_, _, _) =>
         Success(None)
-      case Specified(_, _, _, _, _, _, _, useClient) =>
+      case Specified(_, _, _, _, _, _, _, useClient, _) =>
         Success(useClient)
       case InitialArgs =>
         argParser.showUsageOnError


### PR DESCRIPTION
## What does this change?
Add support for threaded messages in Hangouts. This is useful when multiple messages are sent in quick succession from the same app, for example RepoCop. Threading messages together, hopefully, reduces the sense of spam/noise.

This change requires a new version of the libraries to be published. The additional field is optional, so should be backwards compatible for clients using older versions of the libraries.

## How to test
Run the "dev" project locally and observe threaded messages:

```sh
sbt "project dev" "run fields --config-stage PROD --targets Stack=deploy --subject test --message testing --source test --hangouts --thread-key test"
```

<img width="1065" alt="image" src="https://github.com/guardian/anghammarad/assets/836140/bb38e736-d4e5-45e6-9ccc-49e86c988acd">