### PR TITLE
Bump `actions-riff-raff` to V4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      # required by aws-actions/configure-aws-credentials
+      # required by actions-riff-raff@v4
       id-token: write
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-
-      # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
-      # See https://github.com/aws-actions/configure-aws-credentials
-      - name: Setup aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
 
       # Configuring caching is also recommended.
       # See https://github.com/actions/setup-java
@@ -43,9 +36,11 @@ jobs:
             ./script/ci
           
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@v2
+        uses: guardian/actions-riff-raff@v4
         with:
           app: anghammarad
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           configPath: anghammarad/riff-raff.yaml
           projectName: tools::anghammarad
           buildNumberOffset: 250


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrade [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff) to [v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4).

## Why?

This allows us to remove the [aws-configure-credentials](https://github.com/aws-actions/configure-aws-credentials) step from the earlier part of the workflow.
See [`actions-riff-raff` change](https://github.com/guardian/actions-riff-raff/pull/108) for details.
