### PR TITLE
Proposal to add .metals/, .vscode/ and .bsp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ cmake-build-debug/
 
 # IntelliJ
 /out/
+.bsp/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/
@@ -153,3 +154,7 @@ project/plugins/project/
 
 
 # End of https://www.gitignore.io/api/sbt,scala,emacs,intellij
+
+# VSCode
+.metals/
+.vscode/


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

While locally testing anghammarad-config against anghammarad earlier, we noticed these three directories were added. 

## How to test

Clone the repo and open in VSCode, then open in IntelliJ.
