### PR TITLE
Fix deployment deprecation warning

### DIFF
--- a/anghammarad/riff-raff.yaml
+++ b/anghammarad/riff-raff.yaml
@@ -12,7 +12,7 @@ deployments:
     type: aws-lambda
     parameters:
       fileName: anghammarad.jar
-      bucket: deploy-tools-dist
+      bucketSsmLookup: true
       prefixStack: false
       functionNames:
       - anghammarad-


### PR DESCRIPTION
## What does this change?

The riff-raff.yaml file should use `bucketSsmLookup` to instruct riff-raff to resolve the bucket name out of SSM. This was appearing as a warning on Aghammarad deployments, so this updates the configuration.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

We'll check that a new deployment works correctly, with no warnings.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

The deployment warnings will no longer appear.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

I've double-checked that the SSM parameter will resolve to the correct value.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
