### PR TITLE
Add Java version - see guardian/gha-scala-library-release-workflow#36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
 
       # Configuring caching is also recommended.
       # See https://github.com/actions/setup-java
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'corretto'
           cache: 'sbt'
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21.0.3.9.1

--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -61,7 +61,7 @@ Resources:
               - s3:GetObject
             Resource: !Sub arn:aws:s3:::${ConfigBucket}/*
       Handler: com.gu.anghammarad.Lambda::handleRequest
-      Runtime: java11
+      Runtime: java21
       MemorySize: 512
       Timeout: 30
       CodeUri:


### PR DESCRIPTION
See https://github.com/guardian/gha-scala-library-release-workflow/pull/36 - [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) has moved to _requiring_ projects to specify what version of Java they want to use to build, and this is expressed through an [`asdf`](https://asdf-vm.com/)-formatted `.tool-versions` file.

This allows individual projects to experiment with later (or even _earlier_) versions of Java if they wish, without requiring all other projects using `gha-scala-library-release-workflow` to upgrade their version of Java at the same time.

#### "But maybe we need to support older versions of Java!"

Note that, although this PR specifies Java 21 (the latest LTS release of Java, which apparently has several performance benefits) for the library _build_, the artifacts released by the project do not need to _require_ Java 21 - so long as the `scalacOptions` defined in the project's `build.sbt` includes a `-release` flag, we can specify that we want the artifacts to support some older version of Java (eg `-release:11` for Java 11).