### PR TITLE
Replace newlines with <br> tags for html content in e-mails

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
@@ -57,7 +57,7 @@ object Messages {
     val markdownWithNotice = markdown + anghammaradNotice(notification)
     val plaintextWithNotice = plaintext + anghammaradNotice(notification)
 
-    val html = mdRenderer.render(mdParser.parse(markdownWithNotice))
+    val html = mdRenderer.render(mdParser.parse(markdownWithNotice)).replace("\n", "<br>")
 
     EmailMessage(
       notification.subject,

--- a/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
@@ -62,6 +62,14 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
     }
 
     "html" - {
+      "for all messages" - {
+        val notification = testNotification("subject", "message line 1\nmessage line 2")
+
+        "replaces newlines with <br> tags" in {
+          emailMessage(notification).html should include("message line 1<br>message line 2")
+        }
+      }
+
       "if actions are present" - {
         val notification = testNotification("subject", "message", Action("cta1", "url1"), Action("cta2", "url2"))
 


### PR DESCRIPTION
## What does this change?

Replace newlines with `<br>` tags for html content in e-mails. HTML has absolutely no respect for newlines – see the 'before' example.

|Before|After|
|--|--|
<img width="633" alt="Screenshot 2024-07-04 at 16 02 05" src="https://github.com/guardian/anghammarad/assets/7767575/23ec0d1d-ad13-4a02-a323-a9e950d0a705">|Pending test|

## How to test

- [x] The new unit test passes
- [ ] A test notification in CODE has the appropriate tags

## How can we measure success?

Clearer alerts when their content is newline-separated – I missed the tags in a security-group alert, hence this PR! ✨ 