### PR TITLE
Fix maven release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,6 @@ jobs:
     uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
     permissions: { contents: write, pull-requests: write }
     secrets:
-      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
       PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
       GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION

## What does this change?

This replaces the old sonatype password secret.

We also rename the file to make it consistent with other release workflows in the organisation.

## How to test

We'll run the release workflow straight after merging this PR, it should fix the error seen in the previous invocation:
https://github.com/guardian/anghammarad/actions/runs/10109326671


<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
