### PR TITLE
Downgrade Scala version (use latest LTS version)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val assemblySettings = Seq(
 )
 
 inThisBuild(Seq(
-  scalaVersion := "3.4.0",
+  scalaVersion := "3.3.3",
   crossScalaVersions := Seq("2.13.14", scalaVersion.value),
   scalacOptions ++= Seq(
     "-deprecation",


### PR DESCRIPTION
## What does this change?

We were automatically upgraded[^1] to a non-LTS (i.e. Scala Next) version of Scala in https://github.com/guardian/anghammarad/pull/170. This is [undesirable for this repo](https://scala-lang.org/blog/2023/05/30/scala-3.3.0-released.html), as it produces a Scala library as well as hosting the code for the Anghammarad Lambda:

> LTS might be a great choice for library authors who can now receive constant bug fixes and developer experience improvements without forcing the users of the library to update the compiler version in their project.

After the downgrade consumers of this library can still choose to use `3.4.X` or `3.5.X` if they want to, but by remaining on the LTS version we avoid forcing all consumers to upgrade.

[^1]: The rules for this bot have been [updated](https://github.com/guardian/scala-steward-public-repos/pull/63), so this should not happen again.