### PR TITLE
Upgrade to AWS SDK v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,9 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # Configuring caching is also recommended.
-      # See https://github.com/actions/setup-java
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'corretto'
-          cache: 'sbt'
+      - uses: guardian/setup-scala@v1
 
       - name: Build
         run: |

--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/EmailService.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/EmailService.scala
@@ -1,8 +1,8 @@
 package com.gu.anghammarad.messages
 
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.simpleemail.model.{Body, Content, Destination, SendEmailRequest, Message => AwsMessage}
-import com.amazonaws.services.simpleemail.{AmazonSimpleEmailService, AmazonSimpleEmailServiceClientBuilder}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ses.model.{Body, Content, Destination, SendEmailRequest, Message => AwsMessage}
+import software.amazon.awssdk.services.ses.SesClient
 import com.gu.anghammarad.models.EmailMessage
 import com.gu.anghammarad.Config
 
@@ -10,24 +10,27 @@ import scala.util.Try
 
 
 object EmailService {
-  val client: AmazonSimpleEmailService = AmazonSimpleEmailServiceClientBuilder.standard().withRegion(Regions.EU_WEST_1)
-    .withCredentials(Config.credentialsProvider)
+  val client = SesClient.builder().region(Region.EU_WEST_1)
+    .credentialsProvider(Config.credentialsProvider)
     .build()
 
   def emailRequest(senderAddress: String, recipientAddress: String, message: EmailMessage): SendEmailRequest = {
-    def buildContent(data: String) = new Content().withCharset("UTF-8").withData(data)
+    def buildContent(data: String) = Content.builder().charset("UTF-8").data(data).build()
 
-    val awsMessage = new AwsMessage()
-      .withSubject(buildContent(message.subject))
-      .withBody(new Body()
-        .withHtml(buildContent(message.html))
-        .withText(buildContent(message.plainText))
+    val awsMessage = AwsMessage.builder()
+      .subject(buildContent(message.subject))
+      .body(Body.builder()
+        .html(buildContent(message.html))
+        .text(buildContent(message.plainText))
+        .build()
       )
+      .build()
 
-    new SendEmailRequest()
-      .withDestination(new Destination().withToAddresses(recipientAddress))
-      .withSource(senderAddress)
-      .withMessage(awsMessage)
+    SendEmailRequest.builder()
+      .destination(Destination.builder().toAddresses(recipientAddress).build())
+      .source(senderAddress)
+      .message(awsMessage)
+      .build()
   }
   def sendEmail(senderAddress: String, recipientAddress: String, message: EmailMessage): Try[Unit] = {
     Try(client.sendEmail(emailRequest(senderAddress, recipientAddress, message)))

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 val assemblySettings = Seq(
   assembly / assemblyMergeStrategy := {
     case path if path.endsWith("module-info.class") => MergeStrategy.last
+    case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first //see https://github.com/sbt/sbt-assembly/issues/362
     case x =>
       val oldStrategy = (assembly / assemblyMergeStrategy).value
       oldStrategy(x)

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ inThisBuild(Seq(
   licenses := Seq(License.Apache2),
 ))
 
-val awsSdkVersion = "1.12.777"
+val awsSdkVersion = "2.29.15"
 val circeVersion = "0.14.10"
 val flexmarkVersion = "0.64.8"
 val scalaTestVersion = "3.2.19"
@@ -67,7 +67,8 @@ lazy val client = project
   .settings(
     name := "anghammarad-client",
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
+      "software.amazon.awssdk" % "sns" % awsSdkVersion,
+
       "org.json" % "json" % "20240303",
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test
@@ -84,9 +85,9 @@ lazy val anghammarad = project
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0",
       "com.amazonaws" % "aws-lambda-java-events" % "3.14.0",
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
-      "com.amazonaws" % "aws-java-sdk-lambda" % awsSdkVersion,
-      "com.amazonaws" % "aws-java-sdk-ses" % awsSdkVersion,
-      "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
+      "software.amazon.awssdk" % "lambda" % awsSdkVersion,
+      "software.amazon.awssdk" % "ses" % awsSdkVersion,
+      "software.amazon.awssdk" % "s3" % awsSdkVersion,
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,

--- a/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
+++ b/client/src/main/scala/com/gu/anghammarad/Anghammarad.scala
@@ -1,10 +1,10 @@
 package com.gu.anghammarad
 
-import com.amazonaws.services.sns.AmazonSNSAsync
-import com.amazonaws.services.sns.model.PublishRequest
 import com.gu.anghammarad.AWS._
 import com.gu.anghammarad.Json._
 import com.gu.anghammarad.models._
+import software.amazon.awssdk.services.sns.SnsAsyncClient
+import software.amazon.awssdk.services.sns.model.PublishRequest
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -25,13 +25,14 @@ object Anghammarad {
     * @return             Future containing the resulting SNS Message ID
     */
   def notify(subject: String, message: String, actions: List[Action], target: List[Target], channel: RequestedChannel,
-             sourceSystem: String, topicArn: String, client: AmazonSNSAsync = defaultClient)
+             sourceSystem: String, topicArn: String, client: SnsAsyncClient = defaultClient)
             (implicit executionContext: ExecutionContext): Future[String] = {
-    val request = new PublishRequest()
-      .withTopicArn(topicArn)
-      .withSubject(subject)
-      .withMessage(messageJson(message, sourceSystem, channel, target, actions))
-    awsToScala(client.publishAsync)(request).map(_.getMessageId)
+    val request = PublishRequest.builder()
+      .topicArn(topicArn)
+      .subject(subject)
+      .message(messageJson(message, sourceSystem, channel, target, actions))
+      .build()
+    asScala(client.publish(request)).map(_.messageId)
   }
 
   /**
@@ -44,11 +45,12 @@ object Anghammarad {
     */
   def notify(notification: Notification, topicArn: String)
             (implicit executionContext: ExecutionContext): Future[String] = {
-    val request = new PublishRequest()
-      .withTopicArn(topicArn)
-      .withSubject(notification.subject)
-      .withMessage(messageJson(notification.message, notification.sourceSystem, notification.channel, notification.target, notification.actions))
-    awsToScala(defaultClient.publishAsync)(request).map(_.getMessageId)
+    val request = PublishRequest.builder()
+      .topicArn(topicArn)
+      .subject(notification.subject)
+      .message(messageJson(notification.message, notification.sourceSystem, notification.channel, notification.target, notification.actions))
+      .build()
+     asScala(defaultClient.publish(request)).map(_.messageId)
   }
 
   /**
@@ -59,12 +61,13 @@ object Anghammarad {
     * @param client       The SNS client used to add your notification to the topic
     * @return             Future containing the resulting SNS Message ID
     */
-  def notify(notification: Notification, topicArn: String, client: AmazonSNSAsync)
+  def notify(notification: Notification, topicArn: String, client: SnsAsyncClient)
             (implicit executionContext: ExecutionContext): Future[String] = {
-    val request = new PublishRequest()
-      .withTopicArn(topicArn)
-      .withSubject(notification.subject)
-      .withMessage(messageJson(notification.message, notification.sourceSystem, notification.channel, notification.target, notification.actions))
-    awsToScala(client.publishAsync)(request).map(_.getMessageId)
+    val request = PublishRequest.builder()
+      .topicArn(topicArn)
+      .subject(notification.subject)
+      .message(messageJson(notification.message, notification.sourceSystem, notification.channel, notification.target, notification.actions))
+      .build()
+    asScala(client.publish(request)).map(_.messageId)
   }
 }


### PR DESCRIPTION
## What does this change?

I recently started to look at [AWS FSBP](https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html) reported issues for one of our AWS account, and enabled [AWS Lambda Inspector](https://docs.aws.amazon.com/inspector/latest/user/scanning-lambda.html).
It immediately identifies that lambda provided by [security-hq](https://github.com/guardian/security-hq/) are still embedding vulnerable version of `Log4j`!

I was surprised by this but found this was due to the [dependency to anghammarad-client](https://github.com/guardian/security-hq/blob/main/build.sbt#L152) which is still using the first version of AWS SDK, which depend [to vulnerable versions of `Log4j`](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.12.778).

The associated changes do the following:

- 89295fa4f04e8ad301b91ba61b2cd8d929ace19c — Migration to the version 2 of the AWS SDK
- 25f6c4e4395dbb117a91871f93a01f3ffca41709 — Move compatibility to `Java 21` (Latest LTS) as SDK upgrade is a breaking change and consumers should be running it or upgrading their runtime as the same time.
- cfafe5be2b9f722c16ac76e0565f21631b7da70d — Adopt [setup-scala](https://github.com/guardian/setup-scala) Github action  


## What are the next steps?

- [ ] Release a new major version of the client
- [ ] Update [security-hq lambda](https://github.com/guardian/security-hq) to use the new client
- [ ] Build a new version and [review how to deploy](https://github.com/guardian/security-hq/blob/main/README.md#deployment-currently-manual)
- [ ] Verify that inspector identified issues are resolved


