### PR TITLE
feat: Add the stage to the message footer

### DIFF
--- a/anghammarad/src/main/scala/com/gu/anghammarad/AnghammaradService.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/AnghammaradService.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 
 
 object AnghammaradService {
-  def run(notification: Notification, config: Configuration): Try[List[(Message, Contact)]] = {
+  def run(notification: Notification, config: Configuration, anghammaradStage: String): Try[List[(Message, Contact)]] = {
     // resolve targets
     for {
       contacts <- Contacts.resolveTargetContacts(notification.target, config.mappings)
@@ -17,7 +17,7 @@ object AnghammaradService {
       // find contacts for each message
       contacts <- Contacts.contactsForMessage(notification.channel, channelContacts)
       // address messages
-      toSend = Messages.createMessages(notification, contacts)
+      toSend = Messages.createMessages(notification, contacts, anghammaradStage)
       // send resolved notifications
       result <- SendMessages.sendAll(config, toSend)
     } yield toSend

--- a/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/Lambda.scala
@@ -17,7 +17,7 @@ class Lambda extends RequestHandler[SNSEvent, Unit] {
       config <- Config.loadConfig(stage)
       configuration <- Serialization.parseConfig(config)
       notification <- parseNotification
-      sent <- AnghammaradService.run(notification, configuration)
+      sent <- AnghammaradService.run(notification, configuration, stage)
     } yield sent
 
     // send notification if result is a failure

--- a/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
+++ b/anghammarad/src/main/scala/com/gu/anghammarad/messages/Messages.scala
@@ -24,16 +24,16 @@ object Messages {
   private[anghammarad] val mdParser = Parser.builder(mdOptions).build
   private[anghammarad] val mdRenderer = HtmlRenderer.builder(mdOptions).build()
 
-  def createMessages(notification: Notification, addressees: List[(Channel, Contact)]): List[(Message, Contact)] = {
+  def createMessages(notification: Notification, addressees: List[(Channel, Contact)], anghammaradStage: String): List[(Message, Contact)] = {
     addressees.map {
       case (Email, contact) =>
-        emailMessage(notification) -> contact
+        emailMessage(notification, anghammaradStage) -> contact
       case (HangoutsChat, contact) =>
-        hangoutMessage(notification) -> contact
+        hangoutMessage(notification, anghammaradStage) -> contact
     }
   }
 
-  def emailMessage(notification: Notification): EmailMessage = {
+  def emailMessage(notification: Notification, anghammaradStage: String): EmailMessage = {
     val (markdown, plaintext) =
       if (notification.actions.isEmpty) {
         (notification.message, notification.message)
@@ -54,8 +54,8 @@ object Messages {
         (notification.message + actionPrefix + htmlActions, notification.message + actionPrefix + plainTextActions)
       }
 
-    val markdownWithNotice = markdown + anghammaradNotice(notification)
-    val plaintextWithNotice = plaintext + anghammaradNotice(notification)
+    val markdownWithNotice = markdown + anghammaradNotice(notification, anghammaradStage)
+    val plaintextWithNotice = plaintext + anghammaradNotice(notification, anghammaradStage)
 
     val html = mdRenderer.render(mdParser.parse(markdownWithNotice)).replace("\n", "<br>")
 
@@ -66,8 +66,8 @@ object Messages {
     )
   }
 
-  def hangoutMessage(notification: Notification): HangoutMessage = {
-    val messageWithAnghammaradNotice = notification.message ++ anghammaradNotice(notification)
+  def hangoutMessage(notification: Notification, anghammaradStage: String): HangoutMessage = {
+    val messageWithAnghammaradNotice = notification.message ++ anghammaradNotice(notification, anghammaradStage)
 
     val html = mdRenderer.render(mdParser.parse(messageWithAnghammaradNotice))
       // hangouts chat supports a subset of tags that differs from the flexmark-generated HTML
@@ -129,10 +129,10 @@ object Messages {
        |""".stripMargin
   }
 
-  private def anghammaradNotice(notification: Notification): String = {
+  private def anghammaradNotice(notification: Notification, anghammaradStage: String): String = {
     s"""
        |
-       |This message was sent by ${notification.sourceSystem} via [Anghammarad](https://github.com/guardian/anghammarad).
+       |This message was sent by ${notification.sourceSystem} via [Anghammarad (${anghammaradStage})](https://github.com/guardian/anghammarad).
        |""".stripMargin
   }
 }

--- a/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
+++ b/anghammarad/src/test/scala/com/gu/anghammarad/MessagesTest.scala
@@ -12,33 +12,35 @@ import scala.util.{Failure, Success}
 
 
 class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
+  val anghammaradStage: String = "TEST"
+
   "emailMessage" - {
     "plain text" - {
       "sets the subject" in {
         val notification = testNotification("subject", "message")
-        emailMessage(notification).subject shouldEqual "subject"
+        emailMessage(notification, anghammaradStage).subject shouldEqual "subject"
       }
 
       "if actions are present" - {
         val notification = testNotification("subject", "message", Action("cta1", "url1"), Action("cta2", "url2"))
 
         "adds divider" in {
-          emailMessage(notification).plainText should include("_____________")
+          emailMessage(notification, anghammaradStage).plainText should include("_____________")
         }
 
         "adds actions after divider" in {
-          val chunks = emailMessage(notification).plainText.split("_____________")
+          val chunks = emailMessage(notification, anghammaradStage).plainText.split("_____________")
           chunks(1) should (include("cta1") and include("url1") and include("cta2") and include("url2"))
         }
 
         "includes the message" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).plainText should include("message")
+          emailMessage(notification, anghammaradStage).plainText should include("message")
         }
 
         "includes the Anghammarad notice with source system" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).plainText should (include(notification.sourceSystem) and include("Anghammarad"))
+          emailMessage(notification, anghammaradStage).plainText should (include(notification.sourceSystem) and include("Anghammarad"))
         }
       }
 
@@ -46,17 +48,17 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
         val notification = testNotification("subject", "message")
 
         "does not add divider" in {
-          emailMessage(notification).plainText should not include "_____________"
+          emailMessage(notification, anghammaradStage).plainText should not include "_____________"
         }
 
         "uses the given message" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).plainText should startWith("message")
+          emailMessage(notification, anghammaradStage).plainText should startWith("message")
         }
 
         "includes the Anghammarad notice with source system" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).plainText should (include(notification.sourceSystem) and include("Anghammarad"))
+          emailMessage(notification, anghammaradStage).plainText should (include(notification.sourceSystem) and include("Anghammarad"))
         }
       }
     }
@@ -66,7 +68,7 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
         val notification = testNotification("subject", "message line 1\nmessage line 2")
 
         "replaces newlines with <br> tags" in {
-          emailMessage(notification).html should include("message line 1<br>message line 2")
+          emailMessage(notification, anghammaradStage).html should include("message line 1<br>message line 2")
         }
       }
 
@@ -74,22 +76,22 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
         val notification = testNotification("subject", "message", Action("cta1", "url1"), Action("cta2", "url2"))
 
         "adds divider" in {
-          emailMessage(notification).html should include("<hr")
+          emailMessage(notification, anghammaradStage).html should include("<hr")
         }
 
         "adds actions after divider" in {
-          val chunks = emailMessage(notification).html.split("<hr")
+          val chunks = emailMessage(notification, anghammaradStage).html.split("<hr")
           chunks(1) should (include("""<a href="url1">cta1</a>""") and include("""<a href="url2">cta2</a>"""))
         }
 
         "includes the given message if it is simple" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).html should include("message")
+          emailMessage(notification, anghammaradStage).html should include("message")
         }
 
         "includes the Anghammarad notice with source system" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).html should (include(notification.sourceSystem) and include("Anghammarad"))
+          emailMessage(notification, anghammaradStage).html should (include(notification.sourceSystem) and include("Anghammarad"))
         }
       }
 
@@ -97,22 +99,22 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
         val notification = testNotification("subject", "message")
 
         "does not add divider" in {
-          emailMessage(notification).html should not include "<hr"
+          emailMessage(notification, anghammaradStage).html should not include "<hr"
         }
 
         "includes the given message if it is simple" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).html should include("message")
+          emailMessage(notification, anghammaradStage).html should include("message")
         }
 
         "converts markdown to HTML" in {
           val notification = testNotification("subject", "*em* **strong**")
-          emailMessage(notification).html should (include("<em>em</em>") and include("<strong>strong</strong>"))
+          emailMessage(notification, anghammaradStage).html should (include("<em>em</em>") and include("<strong>strong</strong>"))
         }
 
         "includes the Anghammarad notice with source system" in {
           val notification = testNotification("subject", "message")
-          emailMessage(notification).html should (include(notification.sourceSystem) and include("Anghammarad"))
+          emailMessage(notification, anghammaradStage).html should (include(notification.sourceSystem) and include("Anghammarad"))
         }
       }
     }
@@ -123,7 +125,7 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
       val notification = testNotification("subject", "message", Action("cta1", "url1"), Action("cta2", "url2"))
 
       "is valid JSON" in {
-        val message = hangoutMessage(notification)
+        val message = hangoutMessage(notification, anghammaradStage)
         val result = parse(message.cardJson)
         result match {
           case Right(_) =>
@@ -132,18 +134,18 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
       }
 
       "includes buttons for actions" in {
-        val message = hangoutMessage(notification)
+        val message = hangoutMessage(notification, anghammaradStage)
         val json = parse(message.cardJson).value
         json.\\("textButton") should have length 2
       }
 
       "sets header as subject" in {
-        val message = hangoutMessage(notification)
+        val message = hangoutMessage(notification, anghammaradStage)
         message.cardJson should include(s""""header": "subject"""")
       }
 
       "includes the Anghammarad notice with source system" in {
-        val message = hangoutMessage(notification)
+        val message = hangoutMessage(notification, anghammaradStage)
         message.cardJson should (include(notification.sourceSystem) and include("Anghammarad"))
       }
     }
@@ -152,7 +154,7 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
       val notification = testNotification("subject", "message")
 
       "is valid JSON" in {
-        val message = hangoutMessage(notification)
+        val message = hangoutMessage(notification, anghammaradStage)
         val result = parse(message.cardJson)
         result match {
           case Right(_) =>
@@ -161,13 +163,13 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
       }
 
       "does not include buttons widgets at all" in {
-        val message = hangoutMessage(notification)
+        val message = hangoutMessage(notification, anghammaradStage)
         val json = parse(message.cardJson).value
         json.\\("buttons") shouldBe empty
       }
 
       "includes the Anghammarad notice with source system" in {
-        val message = hangoutMessage(notification)
+        val message = hangoutMessage(notification, anghammaradStage)
         message.cardJson should (include(notification.sourceSystem) and include("Anghammarad"))
       }
     }
@@ -196,7 +198,7 @@ class MessagesTest extends AnyFreeSpec with Matchers with EitherValues {
       "Testing",
       None
     )
-    val message = Messages.hangoutMessage(notification)
+    val message = Messages.hangoutMessage(notification, anghammaradStage)
     // println(message.cardJson)
     val result = HangoutsService.sendHangoutsMessage("???", message)
     result match {

--- a/dev/src/main/scala/com/gu/anghammarad/Main.scala
+++ b/dev/src/main/scala/com/gu/anghammarad/Main.scala
@@ -20,7 +20,7 @@ object Main {
     val sentMessages = for {
       config <- Config.loadConfig(stage)
       configuration <- Serialization.parseConfig(config)
-      sent <- AnghammaradService.run(notification, configuration)
+      sent <- AnghammaradService.run(notification, configuration, stage)
     } yield sent
 
     sentMessages match {


### PR DESCRIPTION
## What does this change?
I wanted to test https://github.com/guardian/anghammarad-config/pull/91, so I ran the following command:

```bash
aws sns publish \
  --subject "testing testing" \
  --message '{"message":"this is a test following https://github.com/guardian/anghammarad-config/pull/91","sender":"test","channel":"all","target":{"Stack":"deploy"},"actions":[]}' \
  --topic-arn $TOPIC_ARN \
  --region eu-west-1 \
  --profile deployTools
```

I hadn't spotted that I had assigned `TOPIC_ARN` to the CODE SNS topic. The changes of https://github.com/guardian/anghammarad-config/pull/91 hadn't been deployed to Anghammarad CODE, so the message was routed to the "old" places. This confused me, as I was expecting it to go to the "new" places.

As a way of signalling which version of Anghammarad sent a message, add the stage to the message footer. Going from: "This message was sent by test via Anghammarad." to: "This message was sent by test via Anghammarad (PROD)."