### PR TITLE
chore(dependency-graph): Use `guardian/setup-scala` in workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: guardian/setup-scala@v1
       - uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
     permissions:
       contents: write


### PR DESCRIPTION
## What does this change?
Uses https://github.com/guardian/setup-scala in the dependency graph workflow. This ensures the `sbt` command is available.