### PR TITLE
chore(deps): Update AWS SDK from 2.31.78 to 2.32.25

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ inThisBuild(Seq(
   licenses := Seq(License.Apache2),
 ))
 
-val awsSdkVersion = "2.31.78"
+val awsSdkVersion = "2.32.25"
 val circeVersion = "0.14.14"
 val flexmarkVersion = "0.64.8"
 val scalaTestVersion = "3.2.19"


### PR DESCRIPTION
## What does this change?
Updates the AWS SDK to [2.32.25](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.32.25). Included in this version is an update to netty 4.1.124, which should resolve https://github.com/guardian/anghammarad/security/dependabot/45.