### PR TITLE
Bump AWS SDK to 2.42.26 to fix Netty CVEs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ inThisBuild(Seq(
   licenses := Seq(License.Apache2),
 ))
 
-val awsSdkVersion = "2.41.34"
+val awsSdkVersion = "2.42.26"
 val circeVersion = "0.14.15"
 val flexmarkVersion = "0.64.8"
 val scalaTestVersion = "3.2.19"


### PR DESCRIPTION
## What does this change?

Bumps aws sdk to latest version to fix GHSA-pwqr-wmgm-9rr8 and GHSA-w9fj-cfpg-grvv.