### PR TITLE
chore: Update CODEOWNERS syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-@guardian/devx-reliability-and-ops
-@guardian/devx-security
+* @guardian/devx-reliability-and-ops
+* @guardian/devx-security


### PR DESCRIPTION
## What does this change?
When opening a PR, we want CODEOWNERS to automatically be added as reviewers. When this happens, to see open PRs, we can perform a GitHub search - https://github.com/pulls/962655?q=is%3Aopen+sort%3Acreated-desc+archived%3Afalse+-state%3Adraft++review%3Arequired+team-review-requested%3Aguardian%2Fdevx-reliability-and-ops.

To achieve this, it looks like CODEOWNERS syntax needs to be `<FILE PATTERN> <GITHUB TEAM>`. Confusingly, both forms are valid:

<img width="406" height="300" alt="image" src="https://github.com/user-attachments/assets/c0efadea-ac52-4183-bfb0-cbcfce38083f" />

<img width="453" height="323" alt="image" src="https://github.com/user-attachments/assets/08bf019d-5aa1-4ccf-b6af-856f43a19941" />

